### PR TITLE
Cmake: Policy version fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.15...3.31)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.15)
 
 option(CODESIGN_IDENTITY "The identity to use for macOS code signing.")
 set(FRONTEND "SDL3" CACHE STRING "Choose which frontend to use.")


### PR DESCRIPTION
When configuring CMake I get the following error: 

```
CMake Error at externals/dynarmic/externals/robin-map/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

I have gotten around this by adding `-DCMAKE_POLICY_VERSION_MINIMUM=3.15` as a config flag.

This PR sets the policy minimum in the main CMakeLists.txt so the flag is no longer needed. 
