### PR TITLE
Set up Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - '**'
       - '!.github/**'
       - '!**.yml'
-      - '.github/workflows/macos.yml'
+      - '.github/workflows/ci.yml'
       - '!**.md'
 
 jobs:


### PR DESCRIPTION
Adds the following builds:

- SwiftUI Release 
- SwiftUI Debug
- SDL Release 
- SDL Debug

The artifacts are uploaded as tar.gz files.
I originally was using a dmg file, but thought this wouldn't be the best way to distribute the SDL builds