### PR TITLE
CI: Create app bundle for SDL builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
         ln -s /Applications image/Applications
         if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
           mv build/bin/Hydra.app image/Hydra.app
-          hdiutil create -volname "Hydra" -srcfolder image/Hydra.app Hydra-${{ matrix.suffix }}
+          hdiutil create -volname "Hydra" -srcfolder image Hydra-${{ matrix.suffix }}
         else
           mv build/bin/Hydra.app image/HydraSDL.app
-          hdiutil create -volname "HydraSDL" -srcfolder image/HydraSDL.app Hydra-${{ matrix.suffix }}
+          hdiutil create -volname "HydraSDL" -srcfolder image Hydra-${{ matrix.suffix }}
         fi
     
     - name: Upload Artifacts - ${{ matrix.suffix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - '**'
       - '!.github/**'
-      - '!**.yml'
       - '.github/workflows/ci.yml'
       - '!**.md'
   
@@ -14,7 +13,6 @@ on:
     paths:
       - '**'
       - '!.github/**'
-      - '!**.yml'
       - '.github/workflows/ci.yml'
       - '!**.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
     - name: Verify CMake Version
       run: cmake --version
   
-    - name: "Select Xcode 16.2"
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-      
-    - name: Verify Xcode Version
-      run: xcodebuild -version
-  
     - name: Set Build Flags
       run: |
         if [[ ${{ matrix.suffix }} == *'Release'* ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,8 @@ jobs:
         fi
         if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
           echo "FRONTEND_MODE=SwiftUI" >> $GITHUB_ENV
-          echo "BUNDLE_MODE=ON" >> $GITHUB_ENV
         else
           echo "FRONTEND_MODE=SDL3" >> $GITHUB_ENV
-          echo "BUNDLE_MODE=OFF" >> $GITHUB_ENV
         fi
   
     - name: Build Hydra
@@ -76,24 +74,25 @@ jobs:
         cmake hydra -B build \
         -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
         -DFRONTEND=${{ env.FRONTEND_MODE }} \
-        -DMACOS_BUNDLE=${{ env.BUNDLE_MODE }} \
+        -DMACOS_BUNDLE=ON \
         -GNinja
         ninja -C build
       
     - name: Create Archive
       run: |
+        mkdir image
+        ln -s /Applications image/Applications
         if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
-          mv build/bin/Hydra.app Hydra.app
-          tar cv Hydra.app | gzip -9 > Hydra-${{ matrix.suffix }}.tar.gz
+          mv build/bin/Hydra.app image/Hydra.app
+          hdiutil create -volname "Hydra" -srcfolder image/Hydra.app Hydra-${{ matrix.suffix }}
         else
-          mkdir Hydra-${{ matrix.suffix }}
-          mv build/bin/hydra Hydra-${{ matrix.suffix }}/hydra
-          tar cv Hydra-${{ matrix.suffix }}/hydra | gzip -9 > Hydra-${{ matrix.suffix }}.tar.gz
+          mv build/bin/Hydra.app image/HydraSDL.app
+          hdiutil create -volname "HydraSDL" -srcfolder image/HydraSDL.app Hydra-${{ matrix.suffix }}
         fi
     
     - name: Upload Artifacts - ${{ matrix.suffix }}
       uses: actions/upload-artifact@v4
       with:
         name: Hydra-${{ matrix.suffix }}
-        path: Hydra-${{ matrix.suffix }}.tar.gz
+        path: Hydra-${{ matrix.suffix }}.dmg
         if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: macos-latest
   
     steps:
+    - name: Set Xcode Version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: Checkout Hydra
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This PR: 

- Uses the `setup-xcode` tool set to latest instead of manually setting it. Removes need to update manually in the future
- Changes the SDL builds to be app bundles. SDL and SwiftUI apps are named differently so they can co-exist
- Changes the archive method to dmg instead of tar.gz
- Small cleanup in workflow dispatch