### PR TITLE
Use macOS 15 on the runner & bump min OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - suffix: SDL-Release
           - suffix: SDL-Debug
   
-    runs-on: macos-latest
+    runs-on: macos-15
   
     steps:
     - name: Set Xcode Version

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NATIVE_SOURCE_FILES
 
 if (FRONTEND STREQUAL "SDL3")
     message(STATUS "Using SDL3 frontend")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
 
     find_package(SDL3 CONFIG REQUIRED)
     set(LINK_LIBS SDL3::SDL3)
@@ -20,6 +21,7 @@ if (FRONTEND STREQUAL "SDL3")
     )
 elseif (FRONTEND STREQUAL "SwiftUI")
     message(STATUS "Using SwiftUI frontend")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 15.0)
 
     add_executable(hydra
         swiftui/HydraApp.swift
@@ -60,7 +62,11 @@ if (MACOS_BUNDLE)
         #MACOSX_BUNDLE_BUNDLE_VERSION ${BUILD_HASH}
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
     )
-    set(MACOSX_MINIMUM_SYSTEM_VERSION "12.0")
+    if (FRONTEND STREQUAL "SwiftUI")
+        set(MACOSX_MINIMUM_SYSTEM_VERSION "15.0")
+    else ()
+        set(MACOSX_MINIMUM_SYSTEM_VERSION "13.0")
+    endif ()
     set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
     set(MACOSX_BUNDLE_BUNDLE_NAME "Hydra")
     set(MACOSX_BUNDLE_COPYRIGHT "Copyright© Hydra Project")


### PR DESCRIPTION
- Sets the build target and min OS to 15 for SwiftUI
- Sets the build target and min OS to 13 for SDL
  - SDL target can be lowered in the future if `hv_vm_config_create` is removed
- Sets the runners to use macOS 15 because `macos-latest` is not the latest, for some reason...

All action now build correctly

Note: changing the target and min OS need to be changed in two places. It would be better if we could change in one place. 

Not sure if something like this would work:
```
   if (FRONTEND STREQUAL "SwiftUI")
        set(CMAKE_OSX_DEPLOYMENT_TARGET 15.0)
.....

        set(MACOSX_MINIMUM_SYSTEM_VERSION CMAKE_OSX_DEPLOYMENT_TARGET)
```
