### PR TITLE
SwiftUI: Small changes to the menu bar

### DIFF
--- a/src/frontend/swiftui/MenuCommands.swift
+++ b/src/frontend/swiftui/MenuCommands.swift
@@ -4,22 +4,23 @@ struct MenuCommands: Commands {
 
     var body: some Commands {
         // Adds a new command to the File menu
-        /*
         CommandGroup(after: .newItem) {
-            Button("Boot Game") {
+            Button("Add to Library") {
+
+            }
+            .keyboardShortcut(KeyEquivalent("o"), modifiers: .command)
+            
+            Button("Boot from File") {
 
             }
             .keyboardShortcut(KeyEquivalent("b"), modifiers: .command)
         }
-        */
+
 
         // This removes/replaces menu items
         CommandGroup(replacing: CommandGroupPlacement.help) {}
         CommandGroup(replacing: CommandGroupPlacement.pasteboard) {}
         CommandGroup(replacing: CommandGroupPlacement.systemServices) {}
         CommandGroup(replacing: CommandGroupPlacement.undoRedo) {}
-
-        // Add the show/hide sidebar command and shortcut to the menu
-        SidebarCommands()
     }
 }

--- a/src/frontend/swiftui/MenuCommands.swift
+++ b/src/frontend/swiftui/MenuCommands.swift
@@ -6,21 +6,20 @@ struct MenuCommands: Commands {
         // Adds a new command to the File menu
         CommandGroup(after: .newItem) {
             Button("Add to Library") {
-
+                // TODO: Implement
             }
             .keyboardShortcut(KeyEquivalent("o"), modifiers: .command)
             
             Button("Boot from File") {
-
+                // TODO: Implement
             }
             .keyboardShortcut(KeyEquivalent("b"), modifiers: .command)
         }
 
-
         // This removes/replaces menu items
         CommandGroup(replacing: CommandGroupPlacement.help) {}
         CommandGroup(replacing: CommandGroupPlacement.pasteboard) {}
-        CommandGroup(replacing: CommandGroupPlacement.systemServices) {}
         CommandGroup(replacing: CommandGroupPlacement.undoRedo) {}
+//        CommandGroup(replacing: CommandGroupPlacement.systemServices) {}
     }
 }

--- a/src/frontend/swiftui/MenuCommands.swift
+++ b/src/frontend/swiftui/MenuCommands.swift
@@ -13,8 +13,11 @@ struct MenuCommands: Commands {
         }
         */
 
-        // This is an example of removing menu items, in this case from the help menu
+        // This removes/replaces menu items
         CommandGroup(replacing: CommandGroupPlacement.help) {}
+        CommandGroup(replacing: CommandGroupPlacement.pasteboard) {}
+        CommandGroup(replacing: CommandGroupPlacement.systemServices) {}
+        CommandGroup(replacing: CommandGroupPlacement.undoRedo) {}
 
         // Add the show/hide sidebar command and shortcut to the menu
         SidebarCommands()


### PR DESCRIPTION
Removes:
- Help menu
- Pasteboard
- Undo/Redo
- Show/Hide Sidebar
~~System Services~~

Adds to File menu: 
- `Add to Library` with shortcut of `Command+O`
- `Boot from File` with shortcut of `Command+B`
(These are non-functional for now)

Note: System services might be useful for debugging purposes.

Edit: I tried to set a preprocessor flag so Services would only show on `debug` builds. This worked when building locally, but it didn't work on the CI builds. Decided to keep it for now. 
![Screenshot 2025-06-08 at 10 57 20](https://github.com/user-attachments/assets/85a51117-393f-46e3-a59c-966a07c2ab25)

