### PR TITLE
Handheld mode - part 1

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -164,7 +164,8 @@ void Config::Serialize() {
         graphics["renderer"] = gpu_renderer.Get();
         graphics["shader_backend"] = shader_backend.Get();
         graphics["display_resolution"] = display_resolution.Get();
-        graphics["custom_display_resolution"] = custom_display_resolution.Get();
+        graphics["custom_display_resolution"] =
+            CustomResolution(custom_display_resolution.Get());
     }
 
     {
@@ -307,8 +308,8 @@ void Config::Log() {
     LOG_INFO(Other, "Shader backend: {}", shader_backend);
     LOG_INFO(Other, "Display resolution: {}", display_resolution);
     LOG_INFO(Other, "Custom display resolution: {}x{}",
-             uint2(custom_display_resolution.Get()).x(),
-             uint2(custom_display_resolution.Get()).y());
+             custom_display_resolution.Get().x(),
+             custom_display_resolution.Get().y());
     LOG_INFO(Other, "Audio backend: {}", audio_backend);
     LOG_INFO(Other, "User ID: {:032x}", user_id.Get());
     LOG_INFO(Other, "Firmware path: {}", firmware_path);

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -71,7 +71,6 @@ Config::Config() {
 void Config::LoadDefaults() {
     game_paths = GetDefaultGamePaths();
     patch_paths = GetDefaultPatchPaths();
-    save_path = GetDefaultSavePath();
     cpu_backend = GetDefaultCpuBackend();
     gpu_renderer = GetDefaultGpuRenderer();
     shader_backend = GetDefaultShaderBackend();
@@ -79,6 +78,8 @@ void Config::LoadDefaults() {
     user_id = GetDefaultUserID();
     firmware_path = GetDefaultFirmwarePath();
     sd_card_path = GetDefaultSdCardPath();
+    save_path = GetDefaultSavePath();
+    handheld_mode = GetDefaultHandheldMode();
     log_output = GetDefaultLogOutput();
     log_fs_access = GetDefaultLogFsAccess();
     debug_logging = GetDefaultDebugLogging();
@@ -146,6 +147,7 @@ void Config::Serialize() {
         system["firmware_path"] = firmware_path;
         system["sd_card_path"] = sd_card_path;
         system["save_path"] = save_path;
+        system["handheld_mode"] = handheld_mode;
     }
 
     {
@@ -209,6 +211,8 @@ void Config::Deserialize() {
                                                   GetDefaultSdCardPath());
         save_path = toml::find_or<std::string>(system, "save_path",
                                                GetDefaultSavePath());
+        handheld_mode = toml::find_or<bool>(system, "handheld_mode",
+                                            GetDefaultHandheldMode());
     }
     if (data.contains("Debug")) {
         const auto& debug = data.at("Debug");
@@ -260,6 +264,7 @@ void Config::Log() {
     LOG_INFO(Other, "Firmware path: {}", firmware_path);
     LOG_INFO(Other, "SD card path: {}", sd_card_path);
     LOG_INFO(Other, "Save path: {}", save_path);
+    LOG_INFO(Other, "Handheld mode: {}", handheld_mode);
     LOG_INFO(Other, "Log output: {}", log_output);
     LOG_INFO(Other, "Log FS access: {}", log_fs_access);
     LOG_INFO(Other, "Debug logging: {}", debug_logging);

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -8,8 +8,9 @@ TOML11_DEFINE_CONVERSION_ENUM(hydra::CpuBackend, AppleHypervisor,
 TOML11_DEFINE_CONVERSION_ENUM(hydra::GpuRenderer, Metal, "Metal")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::ShaderBackend, Msl, "MSL", Air, "AIR")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::Resolution, Auto, "auto", _720p, "720p",
-                              _1080p, "1080p", _2160p, "2160p", _4320p, "4320p",
-                              Custom, "custom")
+                              _1080p, "1080p", _1440p, "1440p", _2160p, "2160p",
+                              _4320p, "4320p", AutoExact, "Auto exact", Custom,
+                              "custom")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::AudioBackend, Null, "Null", Cubeb, "Cubeb")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::LogOutput, None, "none", StdOut, "stdout",
                               File, "file")

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -12,32 +12,34 @@ namespace hydra {
 enum class CpuBackend : u32 {
     Invalid = 0,
 
-    AppleHypervisor = 1,
-    Dynarmic = 2,
+    AppleHypervisor,
+    Dynarmic,
 };
 
 enum class GpuRenderer : u32 {
     Invalid = 0,
 
-    Metal = 1,
+    Metal,
 };
 
 enum class ShaderBackend : u32 {
     Invalid = 0,
 
-    Msl = 1,
-    Air = 2,
+    Msl,
+    Air,
 };
 
 enum class Resolution : u32 {
     Invalid = 0,
 
-    Auto = 1,
-    _720p = 2,
-    _1080p = 3,
-    _2160p = 4,
-    _4320p = 5,
-    Custom = 100,
+    Auto,
+    _720p,
+    _1080p,
+    _1440p,
+    _2160p,
+    _4320p,
+    AutoExact,
+    Custom,
 };
 
 STRONG_TYPEDEF(CustomResolution, uint2);
@@ -45,8 +47,8 @@ STRONG_TYPEDEF(CustomResolution, uint2);
 enum class AudioBackend : u32 {
     Invalid = 0,
 
-    Null = 1,
-    Cubeb = 2,
+    Null,
+    Cubeb,
 };
 
 template <typename T>
@@ -233,8 +235,9 @@ ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, GpuRenderer, gpu_renderer, Metal,
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, ShaderBackend, shader_backend, Msl,
                                    "MSL", Air, "AIR")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, Resolution, resolution, Auto, "auto",
-                                   _720p, "720p", _1080p, "1080p", _2160p,
-                                   "2160p", _4320p, "4320p", Custom, "custom")
+                                   _720p, "720p", _1080p, "1080p", _1440p,
+                                   "1440p", _2160p, "2160p", _4320p, "4320p",
+                                   AutoExact, "Auto exact", Custom, "custom")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, AudioBackend, audio_backend, Null,
                                    "Null", Cubeb, "Cubeb")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, LogOutput, output, None, "none",

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -29,6 +29,8 @@ enum class ShaderBackend : u32 {
     Air = 2,
 };
 
+STRONG_TYPEDEF(Resolution, uint2);
+
 enum class AudioBackend : u32 {
     Invalid = 0,
 
@@ -120,6 +122,7 @@ class Config {
     Option<CpuBackend>& GetCpuBackend() { return cpu_backend; }
     Option<GpuRenderer>& GetGpuRenderer() { return gpu_renderer; }
     Option<ShaderBackend>& GetShaderBackend() { return shader_backend; }
+    Option<Resolution>& GetDisplayResolution() { return display_resolution; }
     Option<AudioBackend>& GetAudioBackend() { return audio_backend; }
     Option<uuid_t>& GetUserID() { return user_id; }
     Option<std::string>& GetFirmwarePath() { return firmware_path; }
@@ -142,6 +145,7 @@ class Config {
     Option<CpuBackend> cpu_backend;
     Option<GpuRenderer> gpu_renderer;
     Option<ShaderBackend> shader_backend;
+    Option<Resolution> display_resolution;
     Option<AudioBackend> audio_backend;
     Option<uuid_t> user_id;
     Option<std::string> firmware_path;
@@ -163,6 +167,9 @@ class Config {
     }
     GpuRenderer GetDefaultGpuRenderer() const { return GpuRenderer::Metal; }
     ShaderBackend GetDefaultShaderBackend() const { return ShaderBackend::Msl; }
+    Resolution GetDefaultDisplayResolution() const {
+        return Resolution({1920, 1080});
+    }
     AudioBackend GetDefaultAudioBackend() const { return AudioBackend::Null; }
     uuid_t GetDefaultUserID() const {
         return 0x0; // TODO: INVALID_USER_ID

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -29,7 +29,18 @@ enum class ShaderBackend : u32 {
     Air = 2,
 };
 
-STRONG_TYPEDEF(Resolution, uint2);
+enum class Resolution : u32 {
+    Invalid = 0,
+
+    Auto = 1,
+    _720p = 2,
+    _1080p = 3,
+    _2160p = 4,
+    _4320p = 5,
+    Custom = 100,
+};
+
+STRONG_TYPEDEF(CustomResolution, uint2);
 
 enum class AudioBackend : u32 {
     Invalid = 0,
@@ -123,6 +134,9 @@ class Config {
     Option<GpuRenderer>& GetGpuRenderer() { return gpu_renderer; }
     Option<ShaderBackend>& GetShaderBackend() { return shader_backend; }
     Option<Resolution>& GetDisplayResolution() { return display_resolution; }
+    Option<CustomResolution>& GetCustomDisplayResolution() {
+        return custom_display_resolution;
+    }
     Option<AudioBackend>& GetAudioBackend() { return audio_backend; }
     Option<uuid_t>& GetUserID() { return user_id; }
     Option<std::string>& GetFirmwarePath() { return firmware_path; }
@@ -146,6 +160,7 @@ class Config {
     Option<GpuRenderer> gpu_renderer;
     Option<ShaderBackend> shader_backend;
     Option<Resolution> display_resolution;
+    Option<CustomResolution> custom_display_resolution;
     Option<AudioBackend> audio_backend;
     Option<uuid_t> user_id;
     Option<std::string> firmware_path;
@@ -167,8 +182,9 @@ class Config {
     }
     GpuRenderer GetDefaultGpuRenderer() const { return GpuRenderer::Metal; }
     ShaderBackend GetDefaultShaderBackend() const { return ShaderBackend::Msl; }
-    Resolution GetDefaultDisplayResolution() const {
-        return Resolution({1920, 1080});
+    Resolution GetDefaultDisplayResolution() const { return Resolution::Auto; }
+    CustomResolution GetDefaultCustomDisplayResolution() const {
+        return CustomResolution({1920, 1080});
     }
     AudioBackend GetDefaultAudioBackend() const { return AudioBackend::Null; }
     uuid_t GetDefaultUserID() const {
@@ -216,6 +232,9 @@ ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, GpuRenderer, gpu_renderer, Metal,
                                    "Metal")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, ShaderBackend, shader_backend, Msl,
                                    "MSL", Air, "AIR")
+ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, Resolution, resolution, Auto, "auto",
+                                   _720p, "720p", _1080p, "1080p", _2160p,
+                                   "2160p", _4320p, "4320p", Custom, "custom")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, AudioBackend, audio_backend, Null,
                                    "Null", Cubeb, "Cubeb")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, LogOutput, output, None, "none",

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -125,6 +125,7 @@ class Config {
     Option<std::string>& GetFirmwarePath() { return firmware_path; }
     Option<std::string>& GetSdCardPath() { return sd_card_path; }
     Option<std::string>& GetSavePath() { return save_path; }
+    Option<bool>& GetHandheldMode() { return handheld_mode; }
     Option<LogOutput>& GetLogOutput() { return log_output; }
     Option<bool>& GetLogFsAccess() { return log_fs_access; }
     Option<bool>& GetDebugLogging() { return debug_logging; }
@@ -146,6 +147,7 @@ class Config {
     Option<std::string> firmware_path;
     Option<std::string> sd_card_path;
     Option<std::string> save_path;
+    Option<bool> handheld_mode;
     Option<LogOutput> log_output;
     Option<bool> log_fs_access;
     Option<bool> debug_logging;
@@ -172,6 +174,7 @@ class Config {
     std::string GetDefaultSavePath() const {
         return fmt::format("{}/save", app_data_path);
     }
+    bool GetDefaultHandheldMode() const { return false; }
     LogOutput GetDefaultLogOutput() const { return LogOutput::File; }
     bool GetDefaultLogFsAccess() const { return false; }
     bool GetDefaultDebugLogging() const { return false; }

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -136,7 +136,7 @@ class Config {
     Option<GpuRenderer>& GetGpuRenderer() { return gpu_renderer; }
     Option<ShaderBackend>& GetShaderBackend() { return shader_backend; }
     Option<Resolution>& GetDisplayResolution() { return display_resolution; }
-    Option<CustomResolution>& GetCustomDisplayResolution() {
+    Option<uint2>& GetCustomDisplayResolution() {
         return custom_display_resolution;
     }
     Option<AudioBackend>& GetAudioBackend() { return audio_backend; }
@@ -162,7 +162,7 @@ class Config {
     Option<GpuRenderer> gpu_renderer;
     Option<ShaderBackend> shader_backend;
     Option<Resolution> display_resolution;
-    Option<CustomResolution> custom_display_resolution;
+    Option<uint2> custom_display_resolution;
     Option<AudioBackend> audio_backend;
     Option<uuid_t> user_id;
     Option<std::string> firmware_path;
@@ -185,9 +185,7 @@ class Config {
     GpuRenderer GetDefaultGpuRenderer() const { return GpuRenderer::Metal; }
     ShaderBackend GetDefaultShaderBackend() const { return ShaderBackend::Msl; }
     Resolution GetDefaultDisplayResolution() const { return Resolution::Auto; }
-    CustomResolution GetDefaultCustomDisplayResolution() const {
-        return CustomResolution({1920, 1080});
-    }
+    uint2 GetDefaultCustomDisplayResolution() const { return {1920, 1080}; }
     AudioBackend GetDefaultAudioBackend() const { return AudioBackend::Null; }
     uuid_t GetDefaultUserID() const {
         return 0x0; // TODO: INVALID_USER_ID

--- a/src/common/functions.hpp
+++ b/src/common/functions.hpp
@@ -149,4 +149,22 @@ inline std::string demangle(const std::string& mangled_name) {
     return demangle(mangled_name.c_str());
 }
 
+template <typename T>
+bool str_to_num(const std::string_view str, T& value) {
+    if (str.empty())
+        return false;
+
+    const char* first = str.data();
+    const char* last = str.data() + str.length();
+
+    std::from_chars_result res = std::from_chars(first, last, value);
+
+    if (res.ec != std::errc())
+        return false;
+    if (res.ptr != last)
+        return false;
+
+    return true;
+}
+
 } // namespace hydra

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -181,6 +181,7 @@ class aligned {
 template <typename T>
 class strong_typedef {
   public:
+    strong_typedef() : value{} {}
     strong_typedef(const T& value_) : value{value_} {}
 
     void operator=(const T& new_value) { value = new_value; }

--- a/src/core/c_api.cpp
+++ b/src/core/c_api.cpp
@@ -74,6 +74,16 @@ HYDRA_EXPORT void hydra_string_array_option_set(void* option, uint32_t index,
     static_cast<hydra::ArrayOption<std::string>*>(option)->Set(index, value);
 }
 
+HYDRA_EXPORT uint2 hydra_uint2_option_get(const void* option) {
+    const auto value =
+        static_cast<const hydra::Option<hydra::uint2>*>(option)->Get();
+    return {value.x(), value.y()};
+}
+
+HYDRA_EXPORT void hydra_uint2_option_set(void* option, const uint2 value) {
+    static_cast<hydra::Option<hydra::uint2>*>(option)->Set({value.x, value.y});
+}
+
 // Config
 HYDRA_EXPORT void hydra_config_serialize() {
     hydra::CONFIG_INSTANCE.Serialize();
@@ -103,6 +113,14 @@ HYDRA_EXPORT void* hydra_config_get_shader_backend() {
     return &hydra::CONFIG_INSTANCE.GetShaderBackend();
 }
 
+HYDRA_EXPORT void* hydra_config_get_display_resolution() {
+    return &hydra::CONFIG_INSTANCE.GetDisplayResolution();
+}
+
+HYDRA_EXPORT void* hydra_config_get_custom_display_resolution() {
+    return &hydra::CONFIG_INSTANCE.GetCustomDisplayResolution();
+}
+
 HYDRA_EXPORT void* hydra_config_get_user_id() {
     return &hydra::CONFIG_INSTANCE.GetUserID();
 }
@@ -117,6 +135,10 @@ HYDRA_EXPORT void* hydra_config_get_sd_card_path() {
 
 HYDRA_EXPORT void* hydra_config_get_save_path() {
     return &hydra::CONFIG_INSTANCE.GetSavePath();
+}
+
+HYDRA_EXPORT void* hydra_config_get_handheld_mode() {
+    return &hydra::CONFIG_INSTANCE.GetHandheldMode();
 }
 
 HYDRA_EXPORT void* hydra_config_get_log_output() {
@@ -232,6 +254,11 @@ HYDRA_EXPORT void hydra_emulation_context_request_stop(void* ctx) {
 
 HYDRA_EXPORT void hydra_emulation_context_force_stop(void* ctx) {
     static_cast<hydra::EmulationContext*>(ctx)->ForceStop();
+}
+
+HYDRA_EXPORT void
+hydra_emulation_context_notify_operation_mode_changed(void* ctx) {
+    static_cast<hydra::EmulationContext*>(ctx)->NotifyOperationModeChanged();
 }
 
 HYDRA_EXPORT void hydra_emulation_context_progress_frame(

--- a/src/core/c_api.h
+++ b/src/core/c_api.h
@@ -30,6 +30,19 @@ typedef enum : uint32_t {
 } HydraShaderBackend;
 
 typedef enum : uint32_t {
+    HYDRA_RESOLUTION_INVALID = 0,
+
+    HYDRA_RESOLUTION_AUTO,
+    HYDRA_RESOLUTION_720P,
+    HYDRA_RESOLUTION_1080P,
+    HYDRA_RESOLUTION_1440P,
+    HYDRA_RESOLUTION_2160P,
+    HYDRA_RESOLUTION_4320P,
+    HYDRA_RESOLUTION_AUTO_EXACT,
+    HYDRA_RESOLUTION_CUSTOM,
+} HydraResolution;
+
+typedef enum : uint32_t {
     HYDRA_CONTENT_ARCHIVE_CONTENT_TYPE_PROGRAM = 0,
     HYDRA_CONTENT_ARCHIVE_CONTENT_TYPE_META = 1,
     HYDRA_CONTENT_ARCHIVE_CONTENT_TYPE_CONTROL = 2,
@@ -105,6 +118,14 @@ void hydra_string_array_option_resize(void* option, uint64_t size);
 void hydra_string_array_option_set(void* option, uint32_t index,
                                    const char* value);
 
+typedef struct {
+    uint32_t x;
+    uint32_t y;
+} uint2;
+
+uint2 hydra_uint2_option_get(const void* option);
+void hydra_uint2_option_set(void* option, const uint2 value);
+
 // Config
 void hydra_config_serialize();
 void hydra_config_deserialize();
@@ -114,10 +135,13 @@ void* hydra_config_get_patch_paths();
 void* hydra_config_get_cpu_backend();
 void* hydra_config_get_gpu_renderer();
 void* hydra_config_get_shader_backend();
+void* hydra_config_get_display_resolution();
+void* hydra_config_get_custom_display_resolution();
 void* hydra_config_get_user_id();
 void* hydra_config_get_firmware_path();
 void* hydra_config_get_sd_card_path();
 void* hydra_config_get_save_path();
+void* hydra_config_get_handheld_mode();
 void* hydra_config_get_log_output();
 void* hydra_config_get_debug_logging();
 void* hydra_config_get_process_args();
@@ -149,6 +173,7 @@ void hydra_emulation_context_set_surface(void* ctx, void* surface);
 void hydra_emulation_context_load_and_start(void* ctx, void* loader);
 void hydra_emulation_context_request_stop(void* ctx);
 void hydra_emulation_context_force_stop(void* ctx);
+void hydra_emulation_context_notify_operation_mode_changed(void* ctx);
 
 void hydra_emulation_context_progress_frame(void* ctx, uint32_t width,
                                             uint32_t height,

--- a/src/core/emulation_context.cpp
+++ b/src/core/emulation_context.cpp
@@ -387,6 +387,9 @@ void EmulationContext::ForceStop() {
 
 void EmulationContext::ProgressFrame(u32 width, u32 height,
                                      bool& out_dt_average_updated) {
+    // Set the resolution for OS
+    os->SetSurfaceResolution({width, height});
+
     // Input
     INPUT_DEVICE_MANAGER_INSTANCE.Poll();
 

--- a/src/core/emulation_context.cpp
+++ b/src/core/emulation_context.cpp
@@ -325,9 +325,6 @@ void EmulationContext::LoadAndStart(horizon::loader::LoaderBase* loader) {
 
     LOG_INFO(Other, "-------- Run --------");
 
-    // Connect input devices
-    INPUT_DEVICE_MANAGER_INSTANCE.ConnectDevices();
-
     // Enter focus
     // HACK: games expect focus change to be the second message?
     process->GetAppletState().SendMessage(

--- a/src/core/emulation_context.hpp
+++ b/src/core/emulation_context.hpp
@@ -22,6 +22,7 @@ class EmulationContext {
     void LoadAndStart(horizon::loader::LoaderBase* loader);
     void RequestStop();
     void ForceStop();
+    void NotifyOperationModeChanged() { os->NotifyOperationModeChanged(); }
 
     // TODO: rename?
     void ProgressFrame(u32 width, u32 height, bool& out_dt_average_updated);

--- a/src/core/horizon/hid.hpp
+++ b/src/core/horizon/hid.hpp
@@ -204,6 +204,8 @@ enum class NpadIdType : u8 {
     No8,
     Handheld,
     Other,
+
+    Total,
 };
 
 enum class NpadStyleSet : u32 {
@@ -293,6 +295,7 @@ enum class MouseAttribute {
 };
 
 enum class NpadAttributes : u32 {
+    None = 0,
     IsConnected = BIT(0),
     IsWired = BIT(1),
     IsLeftConnected = BIT(2),
@@ -300,6 +303,7 @@ enum class NpadAttributes : u32 {
     IsRightConnected = BIT(4),
     IsRightWired = BIT(5),
 };
+ENABLE_ENUM_BITMASK_OPERATORS(NpadAttributes)
 
 enum class SixAxisSensorAttribute {
     IsConnected = BIT(0),
@@ -1170,4 +1174,4 @@ struct SharedMemory {
 ENABLE_ENUM_FORMATTING(hydra::horizon::hid::NpadIdType, No1, "Number 1", No2,
                        "Number 2", No3, "Number 3", No4, "Number 4", No5,
                        "Number 5", No6, "Number 6", No7, "Number 7", No8,
-                       "Number 8", Handheld, "Handheld")
+                       "Number 8", Handheld, "Handheld", Total, "Invalid")

--- a/src/core/horizon/input_manager.cpp
+++ b/src/core/horizon/input_manager.cpp
@@ -76,6 +76,14 @@ void InputManager::ConnectNpad(hid::NpadIdType type,
     UPDATE_NPAD_LIFO(type);
 }
 
+void InputManager::DisconnectAllNpads() {
+    for (u32 i = 0; i < u32(hid::NpadIdType::Total); i++) {
+        const auto type = hid::NpadIdType(i);
+        SET_NPAD_ENTRIES_SEPARATE(type, attributes, hid::NpadAttributes::None);
+        UPDATE_NPAD_LIFO(type);
+    }
+}
+
 void InputManager::UpdateNpad(hid::NpadIdType type) { UPDATE_NPAD_LIFO(type); }
 
 void InputManager::SetNpadButtons(hid::NpadIdType type,

--- a/src/core/horizon/input_manager.hpp
+++ b/src/core/horizon/input_manager.hpp
@@ -18,6 +18,9 @@ class InputManager {
     void ConnectNpad(hid::NpadIdType type, hid::NpadStyleSet style_set,
                      hid::NpadAttributes attributes);
 
+    // Device disconnection
+    void DisconnectAllNpads();
+
     // Events
 
     // Npad

--- a/src/core/horizon/os.cpp
+++ b/src/core/horizon/os.cpp
@@ -308,4 +308,27 @@ void OS::NotifyOperationModeChanged() {
     }
 }
 
+uint2 OS::GetDisplayResolution() {
+    if (CONFIG_INSTANCE.GetHandheldMode().Get()) {
+        return {1280, 720}; // Handheld display resolution is fixed
+    } else {
+        switch (CONFIG_INSTANCE.GetDisplayResolution().Get()) {
+        case Resolution::Auto:
+            return {1920, 1080}; // TODO: return the surface size
+        case Resolution::_720p:
+            return {1280, 720};
+        case Resolution::_1080p:
+            return {1920, 1080};
+        case Resolution::_2160p:
+            return {3840, 2160};
+        case Resolution::_4320p:
+            return {7680, 4320};
+        case Resolution::Custom:
+            return CONFIG_INSTANCE.GetCustomDisplayResolution().Get();
+        default:
+            unreachable();
+        }
+    }
+}
+
 } // namespace hydra::horizon

--- a/src/core/horizon/os.hpp
+++ b/src/core/horizon/os.hpp
@@ -31,6 +31,8 @@ class OS {
 
     void NotifyOperationModeChanged();
 
+    static uint2 GetDisplayResolution();
+
   private:
     audio::ICore& audio_core;
     ui::HandlerBase& ui_handler;

--- a/src/core/horizon/os.hpp
+++ b/src/core/horizon/os.hpp
@@ -31,7 +31,8 @@ class OS {
 
     void NotifyOperationModeChanged();
 
-    static uint2 GetDisplayResolution();
+    void SetSurfaceResolution(uint2 resolution);
+    uint2 GetDisplayResolution() const;
 
   private:
     audio::ICore& audio_core;
@@ -51,6 +52,9 @@ class OS {
 
     services::am::LibraryAppletController* library_applet_self_controller{
         nullptr};
+
+    // Display
+    uint2 surface_resolution;
 
   public:
     REF_GETTER(audio_core, GetAudioCore);

--- a/src/core/horizon/os.hpp
+++ b/src/core/horizon/os.hpp
@@ -29,10 +29,7 @@ class OS {
     OS(audio::ICore& audio_core_, ui::HandlerBase& ui_handler_);
     ~OS();
 
-    bool IsInHandheldMode() const {
-        // TODO: make this configurable
-        return true;
-    }
+    void NotifyOperationModeChanged();
 
   private:
     audio::ICore& audio_core;

--- a/src/core/horizon/services/am/common_state_getter.cpp
+++ b/src/core/horizon/services/am/common_state_getter.cpp
@@ -32,8 +32,9 @@ ICommonStateGetter::ReceiveMessage(kernel::Process* process,
 }
 
 result_t ICommonStateGetter::GetOperationMode(OperationMode* out_mode) {
-    *out_mode = OS::GetInstance().IsInHandheldMode() ? OperationMode::Handheld
-                                                     : OperationMode::Console;
+    *out_mode = CONFIG_INSTANCE.GetHandheldMode().Get()
+                    ? OperationMode::Handheld
+                    : OperationMode::Console;
     return RESULT_SUCCESS;
 }
 

--- a/src/core/horizon/services/am/common_state_getter.cpp
+++ b/src/core/horizon/services/am/common_state_getter.cpp
@@ -40,7 +40,7 @@ result_t ICommonStateGetter::GetOperationMode(OperationMode* out_mode) {
 
 result_t ICommonStateGetter::GetDefaultDisplayResolution(i32* out_width,
                                                          i32* out_height) {
-    const auto res = OS::GetDisplayResolution();
+    const auto res = OS_INSTANCE.GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/am/common_state_getter.cpp
+++ b/src/core/horizon/services/am/common_state_getter.cpp
@@ -40,9 +40,9 @@ result_t ICommonStateGetter::GetOperationMode(OperationMode* out_mode) {
 
 result_t ICommonStateGetter::GetDefaultDisplayResolution(i32* out_width,
                                                          i32* out_height) {
-    // TODO: don't hardcode
-    *out_width = 1920;
-    *out_height = 1080;
+    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    *out_width = res.x();
+    *out_height = res.y();
     return RESULT_SUCCESS;
 }
 

--- a/src/core/horizon/services/am/common_state_getter.cpp
+++ b/src/core/horizon/services/am/common_state_getter.cpp
@@ -40,7 +40,7 @@ result_t ICommonStateGetter::GetOperationMode(OperationMode* out_mode) {
 
 result_t ICommonStateGetter::GetDefaultDisplayResolution(i32* out_width,
                                                          i32* out_height) {
-    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    const auto res = OS::GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/am/common_state_getter.hpp
+++ b/src/core/horizon/services/am/common_state_getter.hpp
@@ -21,7 +21,8 @@ class ICommonStateGetter : public IService {
     result_t RequestImpl(RequestContext& context, u32 id) override;
 
   private:
-    kernel::Event* default_display_resolution_change_event;
+    kernel::Event*
+        default_display_resolution_change_event; // TODO: move this to OS
 
     // Commands
     result_t GetEventHandle(kernel::Process* process,

--- a/src/core/horizon/services/hid/hid_server.cpp
+++ b/src/core/horizon/services/hid/hid_server.cpp
@@ -78,6 +78,8 @@ IHidServer::GetPlayerLedPattern(::hydra::horizon::hid::NpadIdType npad_id_type,
     case ::hydra::horizon::hid::NpadIdType::Other:
         *out_pattern = 0b0000;
         break;
+    default:
+        unreachable();
     }
 
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
+++ b/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
@@ -178,7 +178,7 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         binder.QueueBuffer(slot, input);
 
         // Buffer output
-        const auto res = OS::GetDisplayResolution();
+        const auto res = OS_INSTANCE.GetDisplayResolution();
         parcel_writer.Write<display::BqBufferOutput>({
             .width = res.x(),
             .height = res.y(),
@@ -198,10 +198,10 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         u32 value = 0;
         switch (what) {
         case NativeWindowAttribute::Width:
-            value = OS::GetDisplayResolution().x();
+            value = OS_INSTANCE.GetDisplayResolution().x();
             break;
         case NativeWindowAttribute::Height:
-            value = OS::GetDisplayResolution().y();
+            value = OS_INSTANCE.GetDisplayResolution().y();
             break;
         case NativeWindowAttribute::Format:
             value = static_cast<u32>(PixelFormat::RGBA8888); // RGBA8888
@@ -219,7 +219,7 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         auto interface_token = parcel_reader.ReadInterfaceToken();
         LOG_DEBUG(Services, "Interface token: {}", interface_token);
 
-        const auto res = OS::GetDisplayResolution();
+        const auto res = OS_INSTANCE.GetDisplayResolution();
         parcel_writer.Write<display::BqBufferOutput>({
             .width = res.x(),
             .height = res.y(),

--- a/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
+++ b/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
@@ -178,7 +178,7 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         binder.QueueBuffer(slot, input);
 
         // Buffer output
-        const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+        const auto res = OS::GetDisplayResolution();
         parcel_writer.Write<display::BqBufferOutput>({
             .width = res.x(),
             .height = res.y(),
@@ -198,10 +198,10 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         u32 value = 0;
         switch (what) {
         case NativeWindowAttribute::Width:
-            value = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get()).x();
+            value = OS::GetDisplayResolution().x();
             break;
         case NativeWindowAttribute::Height:
-            value = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get()).y();
+            value = OS::GetDisplayResolution().y();
             break;
         case NativeWindowAttribute::Format:
             value = static_cast<u32>(PixelFormat::RGBA8888); // RGBA8888
@@ -219,7 +219,7 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         auto interface_token = parcel_reader.ReadInterfaceToken();
         LOG_DEBUG(Services, "Interface token: {}", interface_token);
 
-        const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+        const auto res = OS::GetDisplayResolution();
         parcel_writer.Write<display::BqBufferOutput>({
             .width = res.x(),
             .height = res.y(),

--- a/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
+++ b/src/core/horizon/services/hosbinder/hos_binder_driver.cpp
@@ -178,11 +178,11 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         binder.QueueBuffer(slot, input);
 
         // Buffer output
-        // TODO
+        const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
         parcel_writer.Write<display::BqBufferOutput>({
-            .width = 1920,       // TODO: don't hardcode
-            .height = 1080,      // TODO: don't hardcode
-            .transform_hint = 0, // HACK
+            .width = res.x(),
+            .height = res.y(),
+            .transform_hint = 0,                                     // HACK
             .num_pending_buffers = display::MAX_BINDER_BUFFER_COUNT, // HACK
         });
 
@@ -198,10 +198,10 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         u32 value = 0;
         switch (what) {
         case NativeWindowAttribute::Width:
-            value = 1920; // TODO: don't hardcode
+            value = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get()).x();
             break;
         case NativeWindowAttribute::Height:
-            value = 1080; // TODO: don't hardcode
+            value = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get()).y();
             break;
         case NativeWindowAttribute::Format:
             value = static_cast<u32>(PixelFormat::RGBA8888); // RGBA8888
@@ -219,10 +219,11 @@ void IHOSBinderDriver::TransactParcelImpl(i32 binder_id, TransactCode code,
         auto interface_token = parcel_reader.ReadInterfaceToken();
         LOG_DEBUG(Services, "Interface token: {}", interface_token);
 
+        const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
         parcel_writer.Write<display::BqBufferOutput>({
-            .width = 1920,       // TODO: don't hardcode
-            .height = 1080,      // TODO: don't hardcode
-            .transform_hint = 0, // HACK
+            .width = res.x(),
+            .height = res.y(),
+            .transform_hint = 0,                                     // HACK
             .num_pending_buffers = display::MAX_BINDER_BUFFER_COUNT, // HACK
         });
 

--- a/src/core/horizon/services/visrv/application_display_service.cpp
+++ b/src/core/horizon/services/visrv/application_display_service.cpp
@@ -75,7 +75,7 @@ result_t IApplicationDisplayService::GetIndirectDisplayTransactionService(
 
 result_t IApplicationDisplayService::ListDisplays(
     u64* out_count, OutBuffer<BufferAttr::MapAlias> out_display_infos_buffer) {
-    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    const auto res = OS::GetDisplayResolution();
     out_display_infos_buffer.writer->Write<DisplayInfo>({
         .name = "Default",
         .has_layer_limit = true,
@@ -110,7 +110,7 @@ result_t IApplicationDisplayService::GetDisplayResolution(u64 display_id,
 
     auto& display = OS_INSTANCE.GetDisplayDriver().GetDisplay(display_id);
 
-    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    const auto res = OS::GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/visrv/application_display_service.cpp
+++ b/src/core/horizon/services/visrv/application_display_service.cpp
@@ -75,13 +75,13 @@ result_t IApplicationDisplayService::GetIndirectDisplayTransactionService(
 
 result_t IApplicationDisplayService::ListDisplays(
     u64* out_count, OutBuffer<BufferAttr::MapAlias> out_display_infos_buffer) {
-    // TODO: don't hardcode
+    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
     out_display_infos_buffer.writer->Write<DisplayInfo>({
         .name = "Default",
         .has_layer_limit = true,
         .layer_count_max = 1,
-        .layer_width_pixel_count_max = 1920,
-        .layer_height_pixel_count_max = 1080,
+        .layer_width_pixel_count_max = res.x(),
+        .layer_height_pixel_count_max = res.y(),
     });
     *out_count = 1;
     return RESULT_SUCCESS;
@@ -110,9 +110,9 @@ result_t IApplicationDisplayService::GetDisplayResolution(u64 display_id,
 
     auto& display = OS_INSTANCE.GetDisplayDriver().GetDisplay(display_id);
 
-    // HACK
-    *out_width = 1920;
-    *out_height = 1080;
+    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    *out_width = res.x();
+    *out_height = res.y();
     return RESULT_SUCCESS;
 }
 

--- a/src/core/horizon/services/visrv/application_display_service.cpp
+++ b/src/core/horizon/services/visrv/application_display_service.cpp
@@ -75,7 +75,7 @@ result_t IApplicationDisplayService::GetIndirectDisplayTransactionService(
 
 result_t IApplicationDisplayService::ListDisplays(
     u64* out_count, OutBuffer<BufferAttr::MapAlias> out_display_infos_buffer) {
-    const auto res = OS::GetDisplayResolution();
+    const auto res = OS_INSTANCE.GetDisplayResolution();
     out_display_infos_buffer.writer->Write<DisplayInfo>({
         .name = "Default",
         .has_layer_limit = true,
@@ -110,7 +110,7 @@ result_t IApplicationDisplayService::GetDisplayResolution(u64 display_id,
 
     auto& display = OS_INSTANCE.GetDisplayDriver().GetDisplay(display_id);
 
-    const auto res = OS::GetDisplayResolution();
+    const auto res = OS_INSTANCE.GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/visrv/system_display_service.cpp
+++ b/src/core/horizon/services/visrv/system_display_service.cpp
@@ -27,9 +27,9 @@ result_t ISystemDisplayService::GetDisplayMode(u64 display_id, u32* out_width,
                                                i32* out_unknown) {
     LOG_FUNC_STUBBED(Services);
 
-    // TODO: get this from the display
-    *out_width = 1920;
-    *out_height = 1080;
+    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    *out_width = res.x();
+    *out_height = res.y();
     *out_refresh_rate = 60.0f;
     *out_unknown = 0;
     return RESULT_SUCCESS;

--- a/src/core/horizon/services/visrv/system_display_service.cpp
+++ b/src/core/horizon/services/visrv/system_display_service.cpp
@@ -1,5 +1,7 @@
 #include "core/horizon/services/visrv/system_display_service.hpp"
 
+#include "core/horizon/os.hpp"
+
 namespace hydra::horizon::services::visrv {
 
 DEFINE_SERVICE_COMMAND_TABLE(ISystemDisplayService, 2207, SetLayerVisibility,
@@ -27,7 +29,7 @@ result_t ISystemDisplayService::GetDisplayMode(u64 display_id, u32* out_width,
                                                i32* out_unknown) {
     LOG_FUNC_STUBBED(Services);
 
-    const auto res = uint2(CONFIG_INSTANCE.GetDisplayResolution().Get());
+    const auto res = OS::GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     *out_refresh_rate = 60.0f;

--- a/src/core/horizon/services/visrv/system_display_service.cpp
+++ b/src/core/horizon/services/visrv/system_display_service.cpp
@@ -29,7 +29,7 @@ result_t ISystemDisplayService::GetDisplayMode(u64 display_id, u32* out_width,
                                                i32* out_unknown) {
     LOG_FUNC_STUBBED(Services);
 
-    const auto res = OS::GetDisplayResolution();
+    const auto res = OS_INSTANCE.GetDisplayResolution();
     *out_width = res.x();
     *out_height = res.y();
     *out_refresh_rate = 60.0f;

--- a/src/core/input/device_manager.hpp
+++ b/src/core/input/device_manager.hpp
@@ -7,7 +7,7 @@
 
 namespace hydra::input {
 
-constexpr u32 NPAD_COUNT = 9; // 8 players + handheld
+constexpr u32 NPAD_COUNT = 8; // 8 players
 
 class DeviceManager {
   public:
@@ -19,7 +19,7 @@ class DeviceManager {
     DeviceManager();
     ~DeviceManager();
 
-    void ConnectDevices();
+    void ConnectNpads();
 
     void Poll();
 
@@ -52,6 +52,8 @@ class DeviceManager {
 
         return it->second;
     }
+
+    void PollNpad(horizon::hid::NpadIdType type, u32 index);
 };
 
 } // namespace hydra::input

--- a/src/core/input/npad_config.cpp
+++ b/src/core/input/npad_config.cpp
@@ -169,7 +169,7 @@ NpadConfig::NpadConfig(horizon::hid::NpadIdType type_) : type{type_} {
 
 void NpadConfig::LoadDefaults() {
     switch (type) {
-    case horizon::hid::NpadIdType::Handheld: // TODO: No1 instead?
+    case horizon::hid::NpadIdType::No1:
         // Devices
         device_names = {"keyboard"};
 

--- a/src/frontend/sdl3/window.cpp
+++ b/src/frontend/sdl3/window.cpp
@@ -57,8 +57,13 @@ void Window::Run() {
 #else
                 if (modifiers & SDL_KMOD_CTRL) {
 #endif
-                    if (e.key.key == SDLK_T)
+                    if (e.key.key == SDLK_T) {
                         emulation_context.TakeScreenshot();
+                    } else if (e.key.key == SDLK_O) {
+                        auto& handheld_mode = CONFIG_INSTANCE.GetHandheldMode();
+                        handheld_mode = !handheld_mode;
+                        emulation_context.NotifyOperationModeChanged();
+                    }
                 }
                 break;
             }

--- a/src/frontend/swiftui/Settings/GraphicsSettingsView.swift
+++ b/src/frontend/swiftui/Settings/GraphicsSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct GraphicsSettingsView: View {
     @State var gpuRenderer: HydraGpuRenderer = HYDRA_GPU_RENDERER_INVALID
     @State var shaderBackend: HydraShaderBackend = HYDRA_SHADER_BACKEND_INVALID
+    @State var displayResolution: HydraResolution = HYDRA_RESOLUTION_INVALID
+    @State var customDisplayResolution: uint2 = uint2(x: 0, y: 0)
 
     var body: some View {
         VStack {
@@ -12,6 +14,28 @@ struct GraphicsSettingsView: View {
             Picker("Shader backend", selection: self.$shaderBackend.rawValue) {
                 Text("MSL (recommended)").tag(HYDRA_SHADER_BACKEND_MSL.rawValue)
                 Text("AIR (broken)").tag(HYDRA_SHADER_BACKEND_AIR.rawValue)
+            }
+            Picker("Display resolution", selection: self.$displayResolution.rawValue) {
+                Text("Auto (recommended)").tag(HYDRA_RESOLUTION_AUTO.rawValue)
+                Text("720p").tag(HYDRA_RESOLUTION_720P.rawValue)
+                Text("1080p").tag(HYDRA_RESOLUTION_1080P.rawValue)
+                Text("1440p").tag(HYDRA_RESOLUTION_1440P.rawValue)
+                Text("2160p").tag(HYDRA_RESOLUTION_2160P.rawValue)
+                Text("4320p").tag(HYDRA_RESOLUTION_4320P.rawValue)
+                Text("Auto exact (not recommended)").tag(HYDRA_RESOLUTION_AUTO_EXACT.rawValue)
+                Text("Custom (not recommended)").tag(HYDRA_RESOLUTION_CUSTOM.rawValue)
+            }
+            if self.displayResolution == HYDRA_RESOLUTION_CUSTOM {
+                HStack {
+                    Text("Custom resolution")
+                    TextField(
+                        "Width", value: self.$customDisplayResolution.x,
+                        format: .number)
+                    Text("x")
+                    TextField(
+                        "Height", value: self.$customDisplayResolution.y,
+                        format: .number)
+                }
             }
         }
         .onAppear {
@@ -28,6 +52,12 @@ struct GraphicsSettingsView: View {
 
         let shaderBackendOption = hydra_config_get_shader_backend()
         self.shaderBackend.rawValue = hydra_u32_option_get(shaderBackendOption)
+
+        let displayResolutionOption = hydra_config_get_display_resolution()
+        self.displayResolution.rawValue = hydra_u32_option_get(displayResolutionOption)
+
+        let customDisplayResolutionOption = hydra_config_get_custom_display_resolution()
+        self.customDisplayResolution = hydra_uint2_option_get(customDisplayResolutionOption)
     }
 
     func save() {
@@ -36,5 +66,11 @@ struct GraphicsSettingsView: View {
 
         let shaderBackendOption = hydra_config_get_shader_backend()
         hydra_u32_option_set(shaderBackendOption, self.shaderBackend.rawValue)
+
+        let displayResolutionOption = hydra_config_get_display_resolution()
+        hydra_u32_option_set(displayResolutionOption, self.displayResolution.rawValue)
+
+        let customDisplayResolutionOption = hydra_config_get_custom_display_resolution()
+        hydra_uint2_option_set(customDisplayResolutionOption, self.customDisplayResolution)
     }
 }


### PR DESCRIPTION
This PR adds a shortcut `Command + O` to turn Handheld mode on and off. Display resolution can also be configured. Most official games still act weirdly after the change, or just crash right away.

Fixes cropped rendering in *One Piece*.