### PR TITLE
CI: Bundle dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         path: hydra
   
     - name: Install Dependencies
-      run: brew install boost fmt sdl3
+      run: brew install boost fmt sdl3 dylibbundler
   
     - name: Verify CMake Version
       run: cmake --version
@@ -69,6 +69,7 @@ jobs:
         -DMACOS_BUNDLE=ON \
         -GNinja
         ninja -C build
+        dylibbundler -of -cd -b -x  build/bin/Hydra.app/Contents/MacOS/Hydra -d build/bin/Hydra.app/Contents/libs
       
     - name: Create Archive
       run: |


### PR DESCRIPTION
Use `dylibbundler` to install dependencies into the app bundle: Hydra.app/Contents/libs 
Prevents the app from crashing on launch if the user doesn't have them installed through Homebrew.

- `libfmt` is required for all builds 
- `libSDL3` is required for the SDL builds

Note: The SDL build artifacts crash on launch (on Tahoe) for some reason but this happens on the main branch so it's not likely to be related to this PR. 