### PR TITLE
CI: Bump runner to macOS 26 to fix crash on launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,7 @@ jobs:
         -DMACOS_BUNDLE=ON \
         -GNinja
         ninja -C build
-        echo "Bundling dependencies"
         dylibbundler -of -cd -b -x  build/bin/Hydra.app/Contents/MacOS/Hydra -d build/bin/Hydra.app/Contents/Frameworks -p @executable_path/../Frameworks/
-        echo "Signing hydra with entitlements"
-        codesign --entitlements hydra.entitlements --force --sign - --timestamp --options runtime build/bin/Hydra.app/Contents/MacOS/Hydra
       
     - name: Create Archive
       run: |

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -92,3 +92,12 @@ if (MACOS_BUNDLE)
     set(MACOSX_BUNDLE_COPYRIGHT "Copyright© Hydra Project")
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}")
 endif ()
+
+# Signing
+set(ENTITLEMENTS_FILE "${PROJECT_SOURCE_DIR}/hydra.entitlements")
+
+# TODO: use --deep?
+add_custom_command(TARGET hydra POST_BUILD VERBATIM
+    COMMAND codesign --entitlements ${ENTITLEMENTS_FILE} --force --sign - --timestamp --options runtime "$<TARGET_FILE:hydra>"
+    COMMENT "Signing hydra with entitlements"
+)


### PR DESCRIPTION
The crash was caused by having a duplicate `LC_RPATH`. 

I was not able to reproduce the issue when building locally on macOS 26, so I tried bumping the runner to 26. `LC_RPATH` is no longer duplicated and the app launches fine now. 

Fixes #65 

Bonus: 
- Use the more conventional `Frameworks` folder instead of dylibbundler's default `libs` folder.
- Bump version number to `0.2.3`

Edit: 
We are also code signing the app twice: Once in CMakeLists and then replacing it again with dylibbundler after copying in the dependencies. So I've moved the code sign step to after it. 

Edit 2: Changing the code signing steps broke the app, so reverting. Should maybe address this in another PR.