### PR TITLE
SwiftUI: Add Hydra version number and git hash to title bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,26 +10,30 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(hydra VERSION 0.2.3 LANGUAGES CXX)
 
-# Set up Git hash (only if git is available and we're in a git repo)
-execute_process(
-    COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# Get the first 7 characters
-string(SUBSTRING ${GIT_HASH} 0 7 GIT_HASH_SHORT)
-if(NOT GIT_HASH_SHORT)
-    set(GIT_HASH_SHORT "0000000")
-endif()
-
-set(GIT_HASH_SHORT "${GIT_HASH_SHORT}" PARENT_SCOPE)
-
-if(GIT_DIRTY)
-    set(GIT_HASH_SHORT "${GIT_HASH_SHORT}+dirty")
-endif()
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(GIT_HASH_SHORT "")
+else ()
+    # Set up Git hash (only if git is available and we're in a git repo)
+    execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    
+    # Get the first 7 characters
+    string(SUBSTRING ${GIT_HASH} 0 7 GIT_HASH_SHORT)
+    if(NOT GIT_HASH_SHORT)
+        set(GIT_HASH_SHORT "0000000")
+    endif()
+    
+    set(GIT_HASH_SHORT "${GIT_HASH_SHORT}" PARENT_SCOPE)
+    
+    if(GIT_DIRTY)
+        set(GIT_HASH_SHORT "${GIT_HASH_SHORT}+dirty")
+    endif()
+endif ()
 
 if (NOT CMAKE_BUILD_TYPE)
     message("Build Type not set, defaulting to Debug...")

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -81,9 +81,14 @@ if (MACOS_BUNDLE)
         MACOSX_BUNDLE ON
         MACOSX_BUNDLE_GUI_IDENTIFIER "com.github.${PROJECT_NAME}"
         MACOSX_BUNDLE_ICON_FILE "hydra.icns"
-        MACOSX_BUNDLE_BUNDLE_VERSION ${GIT_HASH_SHORT}
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
     )
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            MACOSX_BUNDLE_BUNDLE_VERSION ${GIT_HASH_SHORT}
+        )
+    endif ()
+    
     if (FRONTEND STREQUAL "SwiftUI")
         set(MACOSX_MINIMUM_SYSTEM_VERSION "15.0")
     else ()

--- a/src/frontend/swiftui/ContentView.swift
+++ b/src/frontend/swiftui/ContentView.swift
@@ -12,10 +12,13 @@ struct ContentView: View {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
     }
     
-    /// The navigation title (either game name or "Game List") plus version
     private var navigationTitle: String {
-        let gameTitle = activeGame?.name ?? "Game List"
-        return "Hydra v\(appVersion) (\(gitVersion)) | \(gameTitle)"
+        let gameTitle = activeGame?.name ?? ""
+        var titleInsert = ""
+        if activeGame?.name != nil { titleInsert = "  |  \(gameTitle)" }
+        var gitInsert = ""
+        if gitVersion != "" { gitInsert = " (\(gitVersion))"}
+        return "Hydra v\(appVersion)\(gitInsert)\(titleInsert)"
     }
 
     var body: some View {


### PR DESCRIPTION
CMake:
- Get git hash
- Make a short version using only the first 7 characters
- Append `+dirty` if changes are uncommitted 
- Add the short hash to the info.plist

SwiftUI: 
- Read the version number and short hash from info.plist
- Show in navigationTitle

<img width="1692" height="1053" alt="Screenshot 2025-11-16 at 13 01 39" src="https://github.com/user-attachments/assets/0285991e-5adc-46ad-ad55-d775007be4af" />
