### PR TITLE
SwiftUI: Clean up settings a bit

### DIFF
--- a/src/frontend/swiftui/Settings/AudioSettingsView.swift
+++ b/src/frontend/swiftui/Settings/AudioSettingsView.swift
@@ -4,25 +4,29 @@ struct AudioSettingsView: View {
     @State private var audioBackend: HydraAudioBackend = HYDRA_AUDIO_BACKEND_INVALID
 
     var body: some View {
-        GeometryReader { geo in
-            GroupBox {
-                VStack {
-                    Picker("Audio backend", selection: self.$audioBackend.rawValue) {
-                        Text("Null (recommended)").tag(
-                            HYDRA_AUDIO_BACKEND_NULL.rawValue)
-                        Text("Cubeb (experimental)").tag(HYDRA_AUDIO_BACKEND_CUBEB.rawValue)
-                    }
-                    .onChange(of: self.audioBackend.rawValue) { _, newValue in
-                        var audioBackendOption = hydraConfigGetAudioBackend()
-                        audioBackendOption.value = newValue
-                    }
+        Spacer()
+        HStack {
+            Spacer()
+            Form {
+                Picker("Audio backend:", selection: self.$audioBackend.rawValue) {
+                    Text("Null (recommended)")
+                        .tag(HYDRA_AUDIO_BACKEND_NULL.rawValue)
+                    Text("Cubeb (experimental)")
+                        .tag(HYDRA_AUDIO_BACKEND_CUBEB.rawValue)
                 }
-                .frame(width: geo.size.width, height: geo.size.height)
+                .onChange(of: self.audioBackend.rawValue) { _, newValue in
+                    var audioBackendOption = hydraConfigGetAudioBackend()
+                    audioBackendOption.value = newValue
+                }
             }
+            .padding(24)
+            .padding(.horizontal, 64)
+            .onAppear {
+                let audioBackendOption = hydraConfigGetAudioBackend()
+                self.audioBackend.rawValue = audioBackendOption.value
+            }
+            Spacer()
         }
-        .onAppear {
-            let audioBackendOption = hydraConfigGetAudioBackend()
-            self.audioBackend.rawValue = audioBackendOption.value
-        }
+        Spacer()
     }
 }

--- a/src/frontend/swiftui/Settings/CpuSettingsView.swift
+++ b/src/frontend/swiftui/Settings/CpuSettingsView.swift
@@ -4,25 +4,29 @@ struct CpuSettingsView: View {
     @State private var cpuBackend: HydraCpuBackend = HYDRA_CPU_BACKEND_INVALID
 
     var body: some View {
-        GeometryReader { geo in
-            GroupBox {
-                VStack {
-                    Picker("CPU backend", selection: self.$cpuBackend.rawValue) {
-                        Text("Apple Hypervisor (recommended)").tag(
-                            HYDRA_CPU_BACKEND_APPLE_HYPERVISOR.rawValue)
-                        Text("dynarmic").tag(HYDRA_CPU_BACKEND_DYNARMIC.rawValue)
-                    }
-                    .onChange(of: self.cpuBackend.rawValue) { _, newValue in
-                        var cpuBackendOption = hydraConfigGetCpuBackend()
-                        cpuBackendOption.value = newValue
-                    }
+        Spacer()
+        HStack {
+            Spacer()
+            Form {
+                Picker("CPU backend:", selection: self.$cpuBackend.rawValue) {
+                    Text("Apple Hypervisor (recommended)")
+                        .tag(HYDRA_CPU_BACKEND_APPLE_HYPERVISOR.rawValue)
+                    Text("dynarmic")
+                        .tag(HYDRA_CPU_BACKEND_DYNARMIC.rawValue)
                 }
-                .frame(width: geo.size.width, height: geo.size.height)
+                .onChange(of: self.cpuBackend.rawValue) { _, newValue in
+                    var cpuBackendOption = hydraConfigGetCpuBackend()
+                    cpuBackendOption.value = newValue
+                }
             }
+            .padding(24)
+            .padding(.horizontal, 64)
+            .onAppear {
+                let cpuBackendOption = hydraConfigGetCpuBackend()
+                self.cpuBackend.rawValue = cpuBackendOption.value
+            }
+            Spacer()
         }
-        .onAppear {
-            let cpuBackendOption = hydraConfigGetCpuBackend()
-            self.cpuBackend.rawValue = cpuBackendOption.value
-        }
+        Spacer()
     }
 }

--- a/src/frontend/swiftui/Settings/DebugSettingsView.swift
+++ b/src/frontend/swiftui/Settings/DebugSettingsView.swift
@@ -10,70 +10,76 @@ struct DebugSettingsView: View {
     @State private var gdbWaitForClient = false
 
     var body: some View {
-        GeometryReader { geo in
-            GroupBox {
-                VStack {
-                    Picker("Log output", selection: self.$logOutput.rawValue) {
-                        Text("none (not recommended)").tag(
-                            HYDRA_LOG_OUTPUT_NONE.rawValue)
-                        Text("stdout").tag(
-                            HYDRA_LOG_OUTPUT_STD_OUT.rawValue)
-                        Text("file (default)").tag(HYDRA_LOG_OUTPUT_FILE.rawValue)
-                    }
-                    .onChange(of: self.logOutput.rawValue) { _, newValue in
-                        var logOutputOption = hydraConfigGetLogOutput()
-                        logOutputOption.value = newValue
-                    }
-                    Toggle("Log filesystem access", isOn: self.$logFsAccess)
-                        .onChange(of: self.logFsAccess) { _, newValue in
-                            var logFsAccessOption = hydraConfigGetLogFsAccess()
-                            logFsAccessOption.value = newValue
-                        }
-                    Toggle("Debug logging", isOn: self.$debugLogging)
-                        .onChange(of: self.debugLogging) { _, newValue in
-                            var debugLoggingOption = hydraConfigGetDebugLogging()
-                            debugLoggingOption.value = newValue
-                        }
-                        
-                    // TODO: process arguments
-                    Text("GDB")
-                    Toggle("Enabled", isOn: self.$gdbEnabled)
-                        .onChange(of: self.gdbEnabled) { _, newValue in
-                            var gdbEnabledOption = hydraConfigGetGdbEnabled()
-                            gdbEnabledOption.value = newValue
-                        }
-                    TextField("Port", value: self.$gdbPort, formatter: NumberFormatter())
-                        .onChange(of: self.gdbPort) { _, newValue in
-                            var gdbPortOption = hydraConfigGetGdbPort()
-                            gdbPortOption.value = newValue
-                        }
-                    Toggle("Wait for client", isOn: self.$gdbWaitForClient)
-                        .onChange(of: self.gdbWaitForClient) { _, newValue in
-                            var gdbWaitForClientOption = hydraConfigGetGdbWaitForClient()
-                            gdbWaitForClientOption.value = newValue
-                        }
+        Spacer()
+        HStack {
+            Spacer()
+            Form {
+                Picker("Log output:", selection: self.$logOutput.rawValue) {
+                    Text("none (not recommended)")
+                        .tag(HYDRA_LOG_OUTPUT_NONE.rawValue)
+                    Text("stdout")
+                        .tag(HYDRA_LOG_OUTPUT_STD_OUT.rawValue)
+                    Text("file (default)")
+                        .tag(HYDRA_LOG_OUTPUT_FILE.rawValue)
                 }
-                .frame(width: geo.size.width, height: geo.size.height)
+                .onChange(of: self.logOutput.rawValue) { _, newValue in
+                    var logOutputOption = hydraConfigGetLogOutput()
+                    logOutputOption.value = newValue
+                }
+                
+                Toggle("Log filesystem access", isOn: self.$logFsAccess)
+                    .onChange(of: self.logFsAccess) { _, newValue in
+                        var logFsAccessOption = hydraConfigGetLogFsAccess()
+                        logFsAccessOption.value = newValue
+                    }
+                    
+                Toggle("Debug logging", isOn: self.$debugLogging)
+                    .onChange(of: self.debugLogging) { _, newValue in
+                        var debugLoggingOption = hydraConfigGetDebugLogging()
+                        debugLoggingOption.value = newValue
+                    }
+                    
+                // TODO: process arguments
+                Text("GDB")
+                Toggle("Enabled", isOn: self.$gdbEnabled)
+                    .onChange(of: self.gdbEnabled) { _, newValue in
+                        var gdbEnabledOption = hydraConfigGetGdbEnabled()
+                        gdbEnabledOption.value = newValue
+                    }
+                TextField("Port:", value: self.$gdbPort, formatter: NumberFormatter())
+                    .onChange(of: self.gdbPort) { _, newValue in
+                        var gdbPortOption = hydraConfigGetGdbPort()
+                        gdbPortOption.value = newValue
+                    }
+                Toggle("Wait for client", isOn: self.$gdbWaitForClient)
+                    .onChange(of: self.gdbWaitForClient) { _, newValue in
+                        var gdbWaitForClientOption = hydraConfigGetGdbWaitForClient()
+                        gdbWaitForClientOption.value = newValue
+                    }
             }
+            .padding(24)
+            .padding(.horizontal, 64)
+            .onAppear {
+                let logOutputOption = hydraConfigGetLogOutput()
+                self.logOutput.rawValue = logOutputOption.value
+    
+                let logFsAccessOption = hydraConfigGetLogFsAccess()
+                self.logFsAccess = logFsAccessOption.value
+    
+                let debugLoggingOption = hydraConfigGetDebugLogging()
+                self.debugLogging = debugLoggingOption.value
+    
+                let gdbEnabledOption = hydraConfigGetGdbEnabled()
+                self.gdbEnabled = gdbEnabledOption.value
+    
+                let gdbPortOption = hydraConfigGetGdbPort()
+                self.gdbPort = gdbPortOption.value
+    
+                let gdbWaitForClientOption = hydraConfigGetGdbWaitForClient()
+                self.gdbWaitForClient = gdbWaitForClientOption.value
+            }
+            Spacer()
         }
-        .onAppear {
-            let logOutputOption = hydraConfigGetLogOutput()
-            self.logOutput.rawValue = logOutputOption.value
-
-            let logFsAccessOption = hydraConfigGetLogFsAccess()
-            self.logFsAccess = logFsAccessOption.value
-
-            let debugLoggingOption = hydraConfigGetDebugLogging()
-            self.debugLogging = debugLoggingOption.value
-
-            let gdbEnabledOption = hydraConfigGetGdbEnabled()
-            self.gdbEnabled = gdbEnabledOption.value
-
-            let gdbPortOption = hydraConfigGetGdbPort()
-            self.gdbPort = gdbPortOption.value
-
-            let gdbWaitForClientOption = hydraConfigGetGdbWaitForClient()
-            self.gdbWaitForClient = gdbWaitForClientOption.value
-        }
+        Spacer()
     }
 }

--- a/src/frontend/swiftui/Settings/GeneralSettingsView.swift
+++ b/src/frontend/swiftui/Settings/GeneralSettingsView.swift
@@ -9,36 +9,33 @@ struct GeneralSettingsView: View {
     private let hatchType = UTType(exportedAs: "com.samoz256.hatch-document", conformingTo: .data)
 
     var body: some View {
-        GeometryReader { geo in
-            GroupBox {
-                VStack {
-                    Text("Game paths")
-                    EditablePathList(
-                        allowedContentTypes: [.folder, self.switchType],
-                        items: self.$gamePaths
-                    )
-                    .onChange(of: self.gamePaths) { _, newValue in
-                        let gamePathsOption = hydraConfigGetGamePaths()
-                        gamePathsOption.resize(newCount: newValue.count)
-                        for i in 0..<newValue.count {
-                            gamePathsOption.set(at: i, value: newValue[i])
-                        }
-                    }
-                    Text("Patch paths")
-                    EditablePathList(
-                        allowedContentTypes: [.folder, self.hatchType], items: self.$patchPaths
-                    )
-                    .onChange(of: self.patchPaths) { _, newValue in
-                        let patchPathsOption = hydraConfigGetPatchPaths()
-                        patchPathsOption.resize(newCount: newValue.count)
-                        for i in 0..<newValue.count {
-                            patchPathsOption.set(at: i, value: newValue[i])
-                        }
-                    }
+        VStack(alignment: .leading) {
+            Text("Game paths")
+            EditablePathList(
+                allowedContentTypes: [.folder, self.switchType],
+                items: self.$gamePaths
+            )
+            .onChange(of: self.gamePaths) { _, newValue in
+                let gamePathsOption = hydraConfigGetGamePaths()
+                gamePathsOption.resize(newCount: newValue.count)
+                for i in 0..<newValue.count {
+                    gamePathsOption.set(at: i, value: newValue[i])
                 }
-                .frame(width: geo.size.width, height: geo.size.height)
+            }
+            Text("Patch paths")
+            EditablePathList(
+                allowedContentTypes: [.folder, self.hatchType], items: self.$patchPaths
+            )
+            .onChange(of: self.patchPaths) { _, newValue in
+                let patchPathsOption = hydraConfigGetPatchPaths()
+                patchPathsOption.resize(newCount: newValue.count)
+                for i in 0..<newValue.count {
+                    patchPathsOption.set(at: i, value: newValue[i])
+                }
             }
         }
+        .padding(24)
+        .padding(.horizontal, 24)
         .onAppear {
             let gamePathsOption = hydraConfigGetGamePaths()
             self.gamePaths = []

--- a/src/frontend/swiftui/Settings/GraphicsSettingsView.swift
+++ b/src/frontend/swiftui/Settings/GraphicsSettingsView.swift
@@ -7,70 +7,73 @@ struct GraphicsSettingsView: View {
     @State private var customDisplayResolution: hydra_uint2 = hydra_uint2(x: 0, y: 0)
 
     var body: some View {
-        GeometryReader { geo in 
-            GroupBox {
-                VStack {
-                    Picker("Gpu renderer", selection: self.$gpuRenderer.rawValue) {
-                        Text("Metal (recommended)").tag(HYDRA_GPU_RENDERER_METAL.rawValue)
-                    }
-                    .onChange(of: self.gpuRenderer.rawValue) { _, newValue in
-                        var gpuRendererOption = hydraConfigGetGpuRenderer()
-                        gpuRendererOption.value = newValue
-                    }
-                    Picker("Shader backend", selection: self.$shaderBackend.rawValue) {
-                        Text("MSL (recommended)").tag(HYDRA_SHADER_BACKEND_MSL.rawValue)
-                        Text("AIR (broken)").tag(HYDRA_SHADER_BACKEND_AIR.rawValue)
-                    }
-                    .onChange(of: self.shaderBackend.rawValue) { _, newValue in
-                        var shaderBackendOption = hydraConfigGetShaderBackend()
-                        shaderBackendOption.value = newValue
-                    }
-                    Picker("Display resolution", selection: self.$displayResolution.rawValue) {
-                        Text("Auto (recommended)").tag(HYDRA_RESOLUTION_AUTO.rawValue)
-                        Text("720p").tag(HYDRA_RESOLUTION_720P.rawValue)
-                        Text("1080p").tag(HYDRA_RESOLUTION_1080P.rawValue)
-                        Text("1440p").tag(HYDRA_RESOLUTION_1440P.rawValue)
-                        Text("2160p").tag(HYDRA_RESOLUTION_2160P.rawValue)
-                        Text("4320p").tag(HYDRA_RESOLUTION_4320P.rawValue)
-                        Text("Auto exact (not recommended)").tag(HYDRA_RESOLUTION_AUTO_EXACT.rawValue)
-                        Text("Custom (not recommended)").tag(HYDRA_RESOLUTION_CUSTOM.rawValue)
-                    }
-                    .onChange(of: self.displayResolution.rawValue) { _, newValue in
-                        var displayResolutionOption = hydraConfigGetDisplayResolution()
-                        displayResolutionOption.value = newValue
-                    }
-                    if self.displayResolution == HYDRA_RESOLUTION_CUSTOM {
-                        HStack {
-                            Text("Custom resolution")
-                            TextField(
-                                "Width", value: self.$customDisplayResolution.x,
-                                format: .number)
-                            Text("x")
-                            TextField(
-                                "Height", value: self.$customDisplayResolution.y,
-                                format: .number)
-                        }
-                        .onChange(of: self.customDisplayResolution) { _, newValue in
-                            var customDisplayResolutionOption = hydraConfigGetCustomDisplayResolution()
-                            customDisplayResolutionOption.value = newValue
-                        }
+        Spacer()
+        HStack {
+            Spacer()
+            Form {
+                Picker("Gpu renderer:", selection: self.$gpuRenderer.rawValue) {
+                    Text("Metal (recommended)").tag(HYDRA_GPU_RENDERER_METAL.rawValue)
+                }
+                .onChange(of: self.gpuRenderer.rawValue) { _, newValue in
+                    var gpuRendererOption = hydraConfigGetGpuRenderer()
+                    gpuRendererOption.value = newValue
+                }
+                
+                Picker("Shader backend:", selection: self.$shaderBackend.rawValue) {
+                    Text("MSL (recommended)").tag(HYDRA_SHADER_BACKEND_MSL.rawValue)
+                    Text("AIR (broken)").tag(HYDRA_SHADER_BACKEND_AIR.rawValue)
+                }
+                .onChange(of: self.shaderBackend.rawValue) { _, newValue in
+                    var shaderBackendOption = hydraConfigGetShaderBackend()
+                    shaderBackendOption.value = newValue
+                }
+                
+                Picker("Display resolution:", selection: self.$displayResolution.rawValue) {
+                    Text("Auto (recommended)").tag(HYDRA_RESOLUTION_AUTO.rawValue)
+                    Text("720p").tag(HYDRA_RESOLUTION_720P.rawValue)
+                    Text("1080p").tag(HYDRA_RESOLUTION_1080P.rawValue)
+                    Text("1440p").tag(HYDRA_RESOLUTION_1440P.rawValue)
+                    Text("2160p").tag(HYDRA_RESOLUTION_2160P.rawValue)
+                    Text("4320p").tag(HYDRA_RESOLUTION_4320P.rawValue)
+                    Text("Auto exact (not recommended)").tag(HYDRA_RESOLUTION_AUTO_EXACT.rawValue)
+                    Text("Custom (not recommended)").tag(HYDRA_RESOLUTION_CUSTOM.rawValue)
+                }
+                .onChange(of: self.displayResolution.rawValue) { _, newValue in
+                    var displayResolutionOption = hydraConfigGetDisplayResolution()
+                    displayResolutionOption.value = newValue
+                }
+                
+                if self.displayResolution == HYDRA_RESOLUTION_CUSTOM {
+                    Text("Custom Resolution") 
+                    TextField(
+                        "Width:", value: self.$customDisplayResolution.x,
+                        format: .number)
+                    TextField(
+                        "Height:", value: self.$customDisplayResolution.y,
+                        format: .number)
+                    .onChange(of: self.customDisplayResolution) { _, newValue in
+                        var customDisplayResolutionOption = hydraConfigGetCustomDisplayResolution()
+                        customDisplayResolutionOption.value = newValue
                     }
                 }
-                .frame(width: geo.size.width, height: geo.size.height)
             }
+            .padding(24)
+            .padding(.horizontal, 64)
+            .onAppear {
+                let gpuRendererOption = hydraConfigGetGpuRenderer()
+                self.gpuRenderer.rawValue = gpuRendererOption.value
+    
+                let shaderBackendOption = hydraConfigGetShaderBackend()
+                self.shaderBackend.rawValue = shaderBackendOption.value
+    
+                let displayResolutionOption = hydraConfigGetDisplayResolution()
+                self.displayResolution.rawValue = displayResolutionOption.value
+    
+                let customDisplayResolutionOption = hydraConfigGetCustomDisplayResolution()
+                self.customDisplayResolution = customDisplayResolutionOption.value
+            }
+            Spacer()
         }
-        .onAppear {
-            let gpuRendererOption = hydraConfigGetGpuRenderer()
-            self.gpuRenderer.rawValue = gpuRendererOption.value
-
-            let shaderBackendOption = hydraConfigGetShaderBackend()
-            self.shaderBackend.rawValue = shaderBackendOption.value
-
-            let displayResolutionOption = hydraConfigGetDisplayResolution()
-            self.displayResolution.rawValue = displayResolutionOption.value
-
-            let customDisplayResolutionOption = hydraConfigGetCustomDisplayResolution()
-            self.customDisplayResolution = customDisplayResolutionOption.value
-        }
+        Spacer()
     }
 }

--- a/src/frontend/swiftui/Settings/SettingsView.swift
+++ b/src/frontend/swiftui/Settings/SettingsView.swift
@@ -39,7 +39,7 @@ struct SettingsView: View {
         }
         .padding(20)
         // TODO: don't hardcode the size
-        .frame(width: 800, height: 600)
+        .frame(width: 800)
         .onDisappear {
             hydraConfigSerialize()
         }

--- a/src/frontend/swiftui/Settings/SystemSettingsView.swift
+++ b/src/frontend/swiftui/Settings/SystemSettingsView.swift
@@ -7,58 +7,49 @@ struct SystemSettingsView: View {
     @State private var sysmodulesPath: String = ""
 
     var body: some View {
-        GeometryReader { geo in
-            GroupBox {
-                VStack {
-                    // TODO: use file importers
-                    HStack {
-                        Text("Firmware Path:")
-                        TextField("Firmware Path", text: $firmwarePath)
-                            .onChange(of: firmwarePath) { _, newValue in
-                                var firmwarePathOption = hydraConfigGetFirmwarePath()
-                                firmwarePathOption.value = newValue
-                            }
+        Spacer()
+        HStack {
+            Spacer()
+            Form {
+                // TODO: use file importers
+                TextField("Firmware Path:", text: $firmwarePath)
+                    .onChange(of: firmwarePath) { _, newValue in
+                        var firmwarePathOption = hydraConfigGetFirmwarePath()
+                        firmwarePathOption.value = newValue
                     }
-                    HStack {
-                        Text("SD Card Path:")
-                        TextField("SD Card Path", text: $sdCardPath)
-                            .onChange(of: sdCardPath) { _, newValue in
-                                var sdCardPathOption = hydraConfigGetSdCardPath()
-                                sdCardPathOption.value = newValue
-                            }
+                TextField("SD Card Path:", text: $sdCardPath)
+                    .onChange(of: sdCardPath) { _, newValue in
+                        var sdCardPathOption = hydraConfigGetSdCardPath()
+                        sdCardPathOption.value = newValue
                     }
-                    HStack {
-                        Text("Save Path:")
-                        TextField("Save Path", text: $savePath)
-                            .onChange(of: savePath) { _, newValue in
-                                var savePathOption = hydraConfigGetSavePath()
-                                savePathOption.value = newValue
-                            }
+                TextField("Save Path:", text: $savePath)
+                    .onChange(of: savePath) { _, newValue in
+                        var savePathOption = hydraConfigGetSavePath()
+                        savePathOption.value = newValue
                     }
-                    HStack {
-                        Text("Sysmodules Path:")
-                        TextField("Sysmodules Path", text: $sysmodulesPath)
-                            .onChange(of: sysmodulesPath) { _, newValue in
-                                var sysmodulesPathOption = hydraConfigGetSysmodulesPath()
-                                sysmodulesPathOption.value = newValue
-                            }
+                TextField("Sysmodules Path:", text: $sysmodulesPath)
+                    .onChange(of: sysmodulesPath) { _, newValue in
+                        var sysmodulesPathOption = hydraConfigGetSysmodulesPath()
+                        sysmodulesPathOption.value = newValue
                     }
-                }
-                .frame(width: geo.size.width, height: geo.size.height)
             }
+            .padding(24)
+            .padding(.horizontal, 24)
+            .onAppear {
+                let firmwarePathOption = hydraConfigGetFirmwarePath()
+                self.firmwarePath = firmwarePathOption.value
+    
+                let sdCardPathOption = hydraConfigGetSdCardPath()
+                self.sdCardPath = sdCardPathOption.value
+    
+                let savePathOption = hydraConfigGetSavePath()
+                self.savePath = savePathOption.value
+    
+                let sysmodulesPathOption = hydraConfigGetSysmodulesPath()
+                self.sysmodulesPath = sysmodulesPathOption.value
+            }
+            Spacer()
         }
-        .onAppear {
-            let firmwarePathOption = hydraConfigGetFirmwarePath()
-            self.firmwarePath = firmwarePathOption.value
-
-            let sdCardPathOption = hydraConfigGetSdCardPath()
-            self.sdCardPath = sdCardPathOption.value
-
-            let savePathOption = hydraConfigGetSavePath()
-            self.savePath = savePathOption.value
-
-            let sysmodulesPathOption = hydraConfigGetSysmodulesPath()
-            self.sysmodulesPath = sysmodulesPathOption.value
-        }
+        Spacer()
     }
 }


### PR DESCRIPTION
- Used `Form` and spacers to format and align things
- Removed the hard-coded height of the settings window

Some notes: 
- Game Paths and Patch Paths in General Settings would look better in a single-column Table view, or else in a List
- I'm not sure how to give a toggle a title on the left hand side, like in Safari 
<img width="326" height="36" alt="Screenshot 2025-12-02 at 11 19 54" src="https://github.com/user-attachments/assets/4ec0dc15-5ad9-497b-9802-081d876d3db1" />

