### PR TITLE
SwiftUI: Toolbar Play/Stop/Pause

### DIFF
--- a/src/frontend/swiftui/ContentView.swift
+++ b/src/frontend/swiftui/ContentView.swift
@@ -5,10 +5,6 @@ struct ContentView: View {
     @Binding var emulationContext: HydraEmulationContext?
 
     @State private var fps: Int = 0
-    
-    private var isRunning: Bool {
-        activeGame != nil ? true : false
-    }
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -41,7 +37,7 @@ struct ContentView: View {
                 .navigationBarBackButtonHidden()
         }
         .toolbar { 
-            ToolbarItems(isRunning: isRunning)
+            ToolbarItems(activeGame: self.$activeGame, emulationContext: self.$emulationContext)
         }
         .windowToolbarFullScreenVisibility(.onHover)
         .navigationTitle(navigationTitle)

--- a/src/frontend/swiftui/ToolbarItems.swift
+++ b/src/frontend/swiftui/ToolbarItems.swift
@@ -3,15 +3,27 @@ import UniformTypeIdentifiers
 
 struct ToolbarItems: ToolbarContent {
     @State private var isFilePickerPresented: Bool = false
+    @Binding var activeGame: Game?
+    @Binding var emulationContext: HydraEmulationContext?
+    
+    private var isRunning: Bool {
+        activeGame != nil ? true : false
+    }
 
     private let switchType = UTType(exportedAs: "com.samoz256.switch-document", conformingTo: .data)
     
-    let isRunning: Bool
 
     var body: some ToolbarContent {
         ToolbarItemGroup(placement: .principal) {
             Button("Play", systemImage: "play") {}.disabled(isRunning)
-            Button("Stop", systemImage: "stop") {}.disabled(!isRunning)
+            Button("Stop", systemImage: "stop") {
+                guard let emulationContext = self.emulationContext else { return }
+                emulationContext.requestStop()
+                // TODO: wait a bit?
+                emulationContext.forceStop()
+                self.activeGame = nil
+            }
+            .disabled(!isRunning)
             Button("Pause", systemImage: "pause") {}.disabled(!isRunning)
         }
         


### PR DESCRIPTION
- Removes the back button from the toolbar when running a game
- Adds Play/Stop/Pause buttons to the centre of the toolbar
- Play/Pause are currently non-functional
- Stop button has been implemented
- Buttons are disabled/enabled appropriately depending on whether a game is running or not

Closes #76 