### PR TITLE
SwiftUI: Toolbar - Fix regression and split in-game and game list toolbars

### DIFF
--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -32,7 +32,6 @@ elseif (FRONTEND STREQUAL "SwiftUI")
         swiftui/HydraApp.swift
         swiftui/ContentView.swift
         swiftui/MenuCommands.swift
-        swiftui/ToolbarItems.swift
         swiftui/Game.swift
         swiftui/MetalView.swift
         swiftui/EmulationView.swift
@@ -59,6 +58,8 @@ elseif (FRONTEND STREQUAL "SwiftUI")
         swiftui/settings/SystemSettingsView.swift
         swiftui/settings/DebugSettingsView.swift
         swiftui/settings/SettingsView.swift
+        swiftui/toolbars/GameListToolbarItems.swift
+        swiftui/toolbars/InGameToolbarItems.swift
         swiftui/debugger/Message.swift
         swiftui/debugger/MessageView.swift
         swiftui/debugger/ThreadDebuggerView.swift

--- a/src/frontend/swiftui/ContentView.swift
+++ b/src/frontend/swiftui/ContentView.swift
@@ -41,6 +41,10 @@ struct ContentView: View {
                         game: activeGame, emulationContext: self.$emulationContext, fps: $fps
                     )
                     .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fit)
+                    .toolbar {
+                        InGameToolbarItems(
+                            activeGame: self.$activeGame, emulationContext: self.$emulationContext)
+                    }
                     #if os(iOS)
                         .onAppear {
                             // TODO: if virtual controller enabled
@@ -66,7 +70,7 @@ struct ContentView: View {
                     #endif
                 }
                 .toolbar {
-                    ToolbarItems(
+                    GameListToolbarItems(
                         activeGame: self.$activeGame, emulationContext: self.$emulationContext)
                 }
                 .navigationBarBackButtonHidden()

--- a/src/frontend/swiftui/Toolbars/GameListToolbarItems.swift
+++ b/src/frontend/swiftui/Toolbars/GameListToolbarItems.swift
@@ -14,17 +14,13 @@ private let switchType = UTType(exportedAs: "com.samoz256.switch-document", conf
     private let addGamePlacement = ToolbarItemPlacement.topBarTrailing
 #endif
 
-struct ToolbarItems: ToolbarContent {
+struct GameListToolbarItems: ToolbarContent {
     @Binding var activeGame: Game?
     @Binding var emulationContext: HydraEmulationContext?
 
     @State private var isFirmwareFilePickerPresented = false
     @State private var isGameFilePickerPresented = false
     @State private var showingFirmwareImportError = false
-
-    private var isRunning: Bool {
-        activeGame != nil ? true : false
-    }
 
     var body: some ToolbarContent {
         var firmwarePathOption = hydraConfigGetFirmwarePath()
@@ -76,16 +72,8 @@ struct ToolbarItems: ToolbarContent {
 
         #if os(macOS)
             ToolbarItemGroup(placement: .principal) {
-                Button("Play", systemImage: "play") {}.disabled(isRunning)
-                Button("Stop", systemImage: "stop") {
-                    guard let emulationContext = self.emulationContext else { return }
-                    emulationContext.requestStop()
-                    // TODO: wait a bit?
-                    emulationContext.forceStop()
-                    self.activeGame = nil
-                }
-                .disabled(!isRunning)
-                Button("Pause", systemImage: "pause") {}.disabled(!isRunning)
+                Button("List View", systemImage: "list.bullet") {}
+                Button("Grid View", systemImage: "rectangle.grid.3x2.fill") {}
             }
         #endif
 

--- a/src/frontend/swiftui/Toolbars/InGameToolbarItems.swift
+++ b/src/frontend/swiftui/Toolbars/InGameToolbarItems.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct InGameToolbarItems: ToolbarContent {
+	@Binding var activeGame: Game?
+	@Binding var emulationContext: HydraEmulationContext?
+
+	private var isRunning: Bool {
+		activeGame != nil ? true : false
+	}
+
+	var body: some ToolbarContent {
+		#if os(macOS)
+			ToolbarItemGroup(placement: .principal) {
+				if isRunning {
+					Button("Pause", systemImage: "pause.fill") {}
+				} else {
+					Button("Play", systemImage: "play.fill") {}
+				}
+				Button("Stop", systemImage: "stop.fill") {
+					guard let emulationContext = self.emulationContext else { return }
+					emulationContext.requestStop()
+					// TODO: wait a bit?
+					emulationContext.forceStop()
+					self.activeGame = nil
+				}
+				.disabled(!isRunning)
+				
+			}
+		#endif
+	}
+
+}


### PR DESCRIPTION
- Fixes a regression where the toolbar disappears when running a game
- Splits the toolbar file to separate GameList and InGame toolbars

In the GameList Toolbar: 
- List view options (list or grid, currently non-functional)
- Firmware check
- Add game button

In the InGame Toolbar: 
- Stop and Pause buttons (only stop is working)