### PR TITLE
SwiftUI: Merge play/pause buttons in the toolbar

### DIFF
--- a/src/frontend/swiftui/EmulationToolbarItems.swift
+++ b/src/frontend/swiftui/EmulationToolbarItems.swift
@@ -8,17 +8,21 @@ struct EmulationToolbarItems: ToolbarContent {
     var body: some ToolbarContent {
         #if os(macOS)
             ToolbarItemGroup(placement: .principal) {
-                Button("Resume", systemImage: "play") {
-                    guard let emulationContext = emulationState.emulationContext else { return }
-                    emulationContext.resume()
-                    isRunning = true
-                }.disabled(isRunning)
-                Button("Pause", systemImage: "pause") {
-                    guard let emulationContext = emulationState.emulationContext else { return }
-                    emulationContext.pause()
-                    isRunning = false
-                }.disabled(!isRunning)
-                Button("Stop", systemImage: "stop") {
+                if isRunning {
+                    Button("Pause", systemImage: "pause.fill") {
+                        guard let emulationContext = emulationState.emulationContext else { return }
+                        emulationContext.pause()
+                        isRunning = false
+                    }
+                } else {
+                    Button("Resume", systemImage: "play.fill") {
+                        guard let emulationContext = emulationState.emulationContext else { return }
+                        emulationContext.resume()
+                        isRunning = true
+                    }
+                }
+                
+                Button("Stop", systemImage: "stop.fill") {
                     guard let emulationContext = emulationState.emulationContext else { return }
                     emulationContext.requestStop()
                     // TODO: wait a bit?


### PR DESCRIPTION
Uses an if/else statement to decide which button to show: 
- If game is running, show the pause button 
- If the game is not running (i.e. paused), show the play button

It does not affect how the stop button works.

Also changed the SF symbols to the `.fill` versions