### PR TITLE
CI: remove duplicate rpaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,90 +1,93 @@
 name: macOS
 
 on:
-  workflow_dispatch:
-  push:
-    paths:
-      - '**'
-      - '!.github/**'
-      - '.github/workflows/ci.yml'
-      - '!**.md'
-  
-  pull_request:
-    paths:
-      - '**'
-      - '!.github/**'
-      - '.github/workflows/ci.yml'
-      - '!**.md'
+    workflow_dispatch:
+    push:
+        paths:
+            - "**"
+            - "!.github/**"
+            - ".github/workflows/ci.yml"
+            - "!**.md"
+
+    pull_request:
+        paths:
+            - "**"
+            - "!.github/**"
+            - ".github/workflows/ci.yml"
+            - "!**.md"
 
 jobs:
-  macOS:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - suffix: SwiftUI-Release
-          - suffix: SwiftUI-Debug
-          - suffix: SDL-Release
-          - suffix: SDL-Debug
-  
-    runs-on: macos-15
-  
-    steps:
-    - name: Set Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
+    macOS:
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - suffix: SwiftUI-Release
+                    - suffix: SwiftUI-Debug
+                    - suffix: SDL-Release
+                    - suffix: SDL-Debug
 
-    - name: Checkout Hydra
-      uses: actions/checkout@v4
-      with:
-        repository: SamoZ256/hydra
-        submodules: recursive
-        path: hydra
-  
-    - name: Install Dependencies
-      run: brew install boost fmt sdl3 dylibbundler
-  
-    - name: Verify CMake Version
-      run: cmake --version
-  
-    - name: Set Build Flags
-      run: |
-        if [[ ${{ matrix.suffix }} == *'Release'* ]]; then
-          echo "BUILD_MODE=Release" >> $GITHUB_ENV
-        else 
-          echo "BUILD_MODE=Debug" >> $GITHUB_ENV
-        fi
-        if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
-          echo "FRONTEND_MODE=SwiftUI" >> $GITHUB_ENV
-        else
-          echo "FRONTEND_MODE=SDL3" >> $GITHUB_ENV
-        fi
-  
-    - name: Build Hydra
-      run: |
-        cmake hydra -B build \
-        -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
-        -DFRONTEND=${{ env.FRONTEND_MODE }} \
-        -DMACOS_BUNDLE=ON \
-        -GNinja
-        ninja -C build
-        dylibbundler -of -cd -b -x  build/bin/Hydra.app/Contents/MacOS/Hydra -d build/bin/Hydra.app/Contents/libs
-      
-    - name: Create Archive
-      run: |
-        mkdir image
-        ln -s /Applications image/Applications
-        if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
-          mv build/bin/Hydra.app image/Hydra.app
-        else
-          mv build/bin/Hydra.app image/HydraSDL.app
-        fi
-        hdiutil create -volname "Hydra" -srcfolder image Hydra-${{ matrix.suffix }}
-    
-    - name: Upload Artifacts - ${{ matrix.suffix }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Hydra-${{ matrix.suffix }}
-        path: Hydra-${{ matrix.suffix }}.dmg
-        if-no-files-found: error
+        runs-on: macos-15
+
+        steps:
+            - name: Set Xcode Version
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: latest-stable
+
+            - name: Checkout Hydra
+              uses: actions/checkout@v4
+              with:
+                  repository: SamoZ256/hydra
+                  submodules: recursive
+                  path: hydra
+
+            - name: Install Dependencies
+              run: brew install boost fmt sdl3 dylibbundler
+
+            - name: Verify CMake Version
+              run: cmake --version
+
+            - name: Set Build Flags
+              run: |
+                  if [[ ${{ matrix.suffix }} == *'Release'* ]]; then
+                    echo "BUILD_MODE=Release" >> $GITHUB_ENV
+                  else
+                    echo "BUILD_MODE=Debug" >> $GITHUB_ENV
+                  fi
+                  if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
+                    echo "FRONTEND_MODE=SwiftUI" >> $GITHUB_ENV
+                  else
+                    echo "FRONTEND_MODE=SDL3" >> $GITHUB_ENV
+                  fi
+
+            - name: Build Hydra
+              run: |
+                  cmake hydra -B build \
+                  -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
+                  -DFRONTEND=${{ env.FRONTEND_MODE }} \
+                  -DMACOS_BUNDLE=ON \
+                  -GNinja
+                  ninja -C build
+                  dylibbundler -of -cd -b -x build/bin/Hydra.app/Contents/MacOS/Hydra -d build/bin/Hydra.app/Contents/libs
+                  while install_name_tool -delete_rpath @executable_path/../libs/ build/bin/Hydra.app/Contents/MacOS/Hydra 2>/dev/null; do :; done
+                  install_name_tool -add_rpath @executable_path/../libs/ build/bin/Hydra.app/Contents/MacOS/Hydra
+                  codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - build/bin/Hydra.app/Contents/MacOS/Hydra
+
+            - name: Create Archive
+              run: |
+                  mkdir image
+                  ln -s /Applications image/Applications
+                  if [[ ${{ matrix.suffix }} == *'SwiftUI'* ]]; then
+                    mv build/bin/Hydra.app image/Hydra.app
+                  else
+                    mv build/bin/Hydra.app image/HydraSDL.app
+                  fi
+                  hdiutil create -volname "Hydra" -srcfolder image Hydra-${{ matrix.suffix }}
+
+            - name: Upload Artifacts - ${{ matrix.suffix }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Hydra-${{ matrix.suffix }}
+                  path: Hydra-${{ matrix.suffix }}.dmg
+                  if-no-files-found: error


### PR DESCRIPTION
Removes duplicate `LC_RPATH` (`@executable_path/../libs/`). Fixes #65.