### PR TITLE
SwiftUI: Add unlock framerate button

### DIFF
--- a/src/frontend/swiftui/EmulationToolbarItems.swift
+++ b/src/frontend/swiftui/EmulationToolbarItems.swift
@@ -37,19 +37,6 @@ struct EmulationToolbarItems: ToolbarContent {
                     } label: {
                         ZStack {
                             Image(systemName: "square.stack.3d.down.forward")
-                            Image(systemName: "lock.open")
-                                .symbolVariant(.none)
-                                .font(.footnote)
-                                .offset(x: 10, y: 5)
-                        }
-                    }
-                    .help("Unlock Framerate")
-                } else {
-                    Button{
-                        isFramerateUnlocked.toggle()
-                    } label: {
-                        ZStack {
-                            Image(systemName: "square.stack.3d.down.forward")
                             Image(systemName: "lock")
                                 .symbolVariant(.none)
                                 .font(.footnote)
@@ -57,6 +44,19 @@ struct EmulationToolbarItems: ToolbarContent {
                         }
                     }
                     .help("Lock Framerate to 60fps")
+                } else {
+                    Button{
+                        isFramerateUnlocked.toggle()
+                    } label: {
+                        ZStack {
+                            Image(systemName: "square.stack.3d.down.forward")
+                            Image(systemName: "lock.open")
+                                .symbolVariant(.none)
+                                .font(.footnote)
+                                .offset(x: 10, y: 5)
+                        }
+                    }
+                    .help("Unlock Framerate")
                 }
             }
             


### PR DESCRIPTION
Adds a toolbar button for locking/unlocking the framerate, including tooltips. 


<img width="205" height="136" alt="Screenshot 2026-01-31 at 13 32 38" src="https://github.com/user-attachments/assets/9540a3a6-2bcf-4bf3-8cbf-b5557a9e9cdd" />
<img width="257" height="117" alt="Screenshot 2026-01-31 at 13 33 09" src="https://github.com/user-attachments/assets/349e8cc0-bb9e-4ac6-bfb7-9caef82499b1" />

Should be tested on Sequoia, as `ToolbarSpacer` that is used to separate the buttons was introduced in Tahoe. 

Edit: Functionality not included.... 