### PR TITLE
[SwiftUI] Use picker to choose grid/list views & handheld/console modes

### DIFF
--- a/src/frontend/swiftui/EmulationToolbarItems.swift
+++ b/src/frontend/swiftui/EmulationToolbarItems.swift
@@ -44,6 +44,7 @@ struct EmulationToolbarItems: ToolbarContent {
                         }
                     }
                     .help("Lock Framerate to 60fps")
+
                 } else {
                     Button {
                         isFramerateUnlocked.toggle()

--- a/src/frontend/swiftui/EmulationToolbarItems.swift
+++ b/src/frontend/swiftui/EmulationToolbarItems.swift
@@ -29,10 +29,10 @@ struct EmulationToolbarItems: ToolbarContent {
                     isRunning = globalState.emulationContext!.isRunning()
                 }
             }
-            
+
             ToolbarItemGroup(placement: .confirmationAction) {
                 if isFramerateUnlocked {
-                    Button{
+                    Button {
                         isFramerateUnlocked.toggle()
                     } label: {
                         ZStack {
@@ -45,7 +45,7 @@ struct EmulationToolbarItems: ToolbarContent {
                     }
                     .help("Lock Framerate to 60fps")
                 } else {
-                    Button{
+                    Button {
                         isFramerateUnlocked.toggle()
                     } label: {
                         ZStack {
@@ -59,43 +59,31 @@ struct EmulationToolbarItems: ToolbarContent {
                     .help("Unlock Framerate")
                 }
             }
-            
+
             // This compiler check is only needed when compiling on a macOS version earlier than 26
             #if compiler(>=6.2.3)
                 if #available(macOS 26.0, *) {
                     ToolbarSpacer(.fixed)
                 }
             #endif
-            
-            if #available(macOS 26.0, *) {
-                ToolbarItemGroup(placement: .confirmationAction) {
+
+            ToolbarItemGroup(placement: .confirmationAction) {
+                Picker("Mode", selection: $globalState.isHandheldMode) {
                     Button("Console Mode", systemImage: "inset.filled.tv") {
                         globalState.isHandheldMode.toggle()
                     }
-                    .disabled(!globalState.isHandheldMode)
-                    .help("Change to Console mode")
-                    
+                    .tag(false)
+                    .help("Console mode")
+
                     Button("Handheld Mode", systemImage: "formfitting.gamecontroller.fill") {
                         globalState.isHandheldMode.toggle()
                     }
-                    .disabled(globalState.isHandheldMode)
-                    .help("Change to Handheld mode")
+                    .tag(true)
+                    .help("Handheld mode")
                 }
-            } else {
-                ToolbarItemGroup(placement: .confirmationAction) {
-                    if globalState.isHandheldMode {
-                        Button("Console Mode", systemImage: "inset.filled.tv") {
-                            globalState.isHandheldMode.toggle()
-                        }
-                        .help("Change to Console mode")
-                    } else {
-                       Button("Handheld Mode", systemImage: "formfitting.gamecontroller.fill") {
-                           globalState.isHandheldMode.toggle()
-                       }
-                       .help("Change to Handheld mode")
-                    }
-                }
+                .pickerStyle(.segmented)
             }
+
         #else
             // TODO: options
             ToolbarItemGroup(placement: .principal) {}

--- a/src/frontend/swiftui/GameListToolbarItems.swift
+++ b/src/frontend/swiftui/GameListToolbarItems.swift
@@ -26,15 +26,18 @@ struct GameListToolbarItems: ToolbarContent {
     var body: some ToolbarContent {
         #if os(macOS)
             ToolbarItemGroup(placement: .principal) {
-                Button("List View", systemImage: "list.bullet") {
-                    viewMode = ViewMode.list.rawValue
+                Picker("View Mode", selection: $viewMode) {
+                    Button("List View", systemImage: "list.bullet") {
+                        viewMode = ViewMode.list.rawValue
+                    }
+                    .tag(ViewMode.list.rawValue)
+
+                    Button("Grid View", systemImage: "rectangle.grid.3x2.fill") {
+                        viewMode = ViewMode.grid.rawValue
+                    }
+                    .tag(ViewMode.grid.rawValue)
                 }
-                .disabled(ViewMode(rawValue: viewMode) == .list)
-                
-                Button("Grid View", systemImage: "rectangle.grid.3x2.fill") {
-                    viewMode = ViewMode.grid.rawValue
-                }
-                .disabled(ViewMode(rawValue: viewMode) == .grid)
+                .pickerStyle(.segmented)
             }
         #endif
 


### PR DESCRIPTION
This PR initially implements using a segmented picker for the List/Grid view buttons, as it's a more standard way of doing this type of exclusive selection rather than the disable method previously used. 

It has no functional difference, but visually SwiftUI will highlight the currently selected view: 

macOS 26: 
<img width="135" height="53" alt="Screenshot 2026-03-15 at 13 26 19" src="https://github.com/user-attachments/assets/f68f6825-8a6b-4f26-bf00-a44e304d7f4a" />
macOS 15: 

<img width="191" height="74" alt="Screenshot 2026-03-15 at 17 54 59" src="https://github.com/user-attachments/assets/fd5a0f7e-fb33-4363-8120-df1f3afb5508" />

After implementing it, I had to re-visit the console/handheld mode buttons, as they were not consistent. So I removed the separate Tahoe/Sequoia code and use the same segmented picker. 

macOS 26: 
<img width="114" height="65" alt="Screenshot 2026-03-15 at 17 58 21" src="https://github.com/user-attachments/assets/5d701aea-269b-4bdc-89bd-c78dc48a0aec" />

I'm not able to run any games in my VM, so I can't check how it looks in Sequoia, but it should be similar to the view picker.