### PR TITLE
CI: Bump actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
                   xcode-version: latest-stable
 
             - name: Checkout Hydra
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: SamoZ256/hydra
                   submodules: recursive
@@ -114,7 +114,7 @@ jobs:
                   hdiutil create -volname "Hydra" -srcfolder image Hydra-${{ matrix.suffix }}
 
             - name: Upload Artifacts - ${{ matrix.suffix }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: Hydra-${{ matrix.suffix }}
                   path: Hydra-${{ matrix.suffix }}.dmg


### PR DESCRIPTION
Three actions currently trigger a Node.js [deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This PR updates `checkout` and `upload-artifact` to v6. 

The remaining one is [`setup-xcode`](https://github.com/maxim-lobanov/setup-xcode) which hasn't been updated yet. 