### PR TITLE
Revert "Use std::chrono::steady_clock for get_absolute_time"

### DIFF
--- a/src/common/time.hpp
+++ b/src/common/time.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+// TODO: support cross-platform time functions
+
 #include <chrono>
+#include <mach/mach_time.h>
 
 #include "common/types.hpp"
 
@@ -8,10 +11,6 @@ using namespace std::chrono_literals;
 
 namespace hydra {
 
-inline u64 get_absolute_time() {
-    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::steady_clock::now().time_since_epoch());
-    return static_cast<u64>(dur.count());
-}
+inline u64 get_absolute_time() { return mach_absolute_time(); }
 
 } // namespace hydra


### PR DESCRIPTION
Reverts SamoZ256/hydra#113