### PR TITLE
Make axis values integer at an eariler point

### DIFF
--- a/src/core/horizon/services/hid/internal/npad.cpp
+++ b/src/core/horizon/services/hid/internal/npad.cpp
@@ -4,19 +4,6 @@
 
 namespace hydra::horizon::services::hid::internal {
 
-namespace {
-
-i32 analog_stick_to_int(f32 value) {
-    if (value < 0.0f)
-        return std::max(i16(value * (-std::numeric_limits<i16>::min())),
-                        std::numeric_limits<i16>::min());
-    else
-        return std::min(i16(value * std::numeric_limits<i16>::max()),
-                        std::numeric_limits<i16>::max());
-}
-
-} // namespace
-
 // TODO: should the event be signalled?
 Npad::Npad(NpadInternalState& state_)
     : state{state_}, style_set_update_event{
@@ -124,13 +111,13 @@ void Npad::Update(const input::NpadState& new_state) {
         .buttons = new_state.buttons,
         .analog_stick_l =
             {
-                .x = analog_stick_to_int(new_state.analog_l_x),
-                .y = analog_stick_to_int(new_state.analog_l_y),
+                .x = new_state.analog_l_x,
+                .y = new_state.analog_l_y,
             },
         .analog_stick_r =
             {
-                .x = analog_stick_to_int(new_state.analog_r_x),
-                .y = analog_stick_to_int(new_state.analog_r_y),
+                .x = new_state.analog_r_x,
+                .y = new_state.analog_r_y,
             },
         .attributes = NpadAttributes::IsConnected,
     };

--- a/src/core/input/apple_gc/controller.hpp
+++ b/src/core/input/apple_gc/controller.hpp
@@ -10,7 +10,7 @@ class Controller : public IController {
 
   protected:
     bool IsPressedImpl(ControllerInput input) override;
-    f32 GetAxisValueImpl(ControllerInput input) override;
+    i32 GetAxisValueImpl(ControllerInput input) override;
 
   private:
     id handle;

--- a/src/core/input/apple_gc/controller.mm
+++ b/src/core/input/apple_gc/controller.mm
@@ -46,7 +46,16 @@ bool Controller::IsPressedImpl(ControllerInput input) {
         .isPressed;
 }
 
-f32 Controller::GetAxisValueImpl(ControllerInput input) {
+i32 analog_stick_to_int(f32 value) {
+    if (value < 0.0f)
+        return std::max(i16(value * (-std::numeric_limits<i16>::min())),
+                        std::numeric_limits<i16>::min());
+    else
+        return std::min(i16(value * std::numeric_limits<i16>::max()),
+                        std::numeric_limits<i16>::max());
+}
+
+i32 Controller::GetAxisValueImpl(ControllerInput input) {
 #define AXIS_CASE(input, gc_dpad, direction)                                   \
     case ControllerInput::input:                                               \
         gc_dpad_name = GCInput##gc_dpad;                                       \
@@ -66,7 +75,7 @@ f32 Controller::GetAxisValueImpl(ControllerInput input) {
         AXIS_CASE(StickRDown, RightThumbstick, Down)
     default:
         LOG_NOT_IMPLEMENTED(Input, "Controller axis {}", input);
-        return 0.0f;
+        return 0;
     }
 
 #undef AXIS_CASE
@@ -75,13 +84,13 @@ f32 Controller::GetAxisValueImpl(ControllerInput input) {
                     .physicalInputProfile.dpads[gc_dpad_name];
     switch (dir) {
     case AnalogStickDirection::Right:
-        return dpad.right.value;
+        return analog_stick_to_int(dpad.right.value);
     case AnalogStickDirection::Left:
-        return dpad.left.value;
+        return analog_stick_to_int(dpad.left.value);
     case AnalogStickDirection::Up:
-        return dpad.up.value;
+        return analog_stick_to_int(dpad.up.value);
     case AnalogStickDirection::Down:
-        return dpad.down.value;
+        return analog_stick_to_int(dpad.down.value);
     }
 }
 

--- a/src/core/input/controller.hpp
+++ b/src/core/input/controller.hpp
@@ -60,12 +60,12 @@ class IController : public IDevice {
 
         const auto input = code.GetValue<ControllerInput>();
         if (ControllerInputIsStick(input))
-            return GetAxisValueImpl(input) > 0.5f;
+            return GetAxisValueImpl(input) > std::numeric_limits<i16>::max()/2;
         else
             return IsPressedImpl(input);
     }
 
-    f32 GetAxisValue(const Code& code) override {
+    i32 GetAxisValue(const Code& code) override {
         if (code.GetDeviceType() != DeviceType::Controller)
             return 0.0f;
 
@@ -78,7 +78,7 @@ class IController : public IDevice {
 
   protected:
     virtual bool IsPressedImpl(ControllerInput input) = 0;
-    virtual f32 GetAxisValueImpl(ControllerInput input) = 0;
+    virtual i32 GetAxisValueImpl(ControllerInput input) = 0;
 };
 
 } // namespace hydra::input

--- a/src/core/input/controller.hpp
+++ b/src/core/input/controller.hpp
@@ -67,7 +67,7 @@ class IController : public IDevice {
 
     i32 GetAxisValue(const Code& code) override {
         if (code.GetDeviceType() != DeviceType::Controller)
-            return 0.0f;
+            return 0;
 
         const auto input = code.GetValue<ControllerInput>();
         if (ControllerInputIsStick(input))

--- a/src/core/input/device.hpp
+++ b/src/core/input/device.hpp
@@ -13,7 +13,7 @@ class IDevice {
 
     // Controller
     virtual bool IsPressed([[maybe_unused]] const Code& code) { return false; }
-    virtual f32 GetAxisValue([[maybe_unused]] const Code& code) { return 0.0f; }
+    virtual i32 GetAxisValue([[maybe_unused]] const Code& code) { return 0; }
 
     // Touch screen
     virtual u64 GetNextBeganTouchID() { return invalid<u64>(); };

--- a/src/core/input/keyboard.hpp
+++ b/src/core/input/keyboard.hpp
@@ -71,12 +71,12 @@ class IKeyboard : public IDevice {
         return IsPressedImpl(key);
     }
 
-    f32 GetAxisValue(const Code& code) override {
+    i32 GetAxisValue(const Code& code) override {
         if (code.GetDeviceType() != DeviceType::Keyboard)
-            return 0.0f;
+            return 0;
 
         const auto key = code.GetValue<Key>();
-        return IsPressedImpl(key) ? 1.0f : 0.0f;
+        return IsPressedImpl(key) ? std::numeric_limits<i16>::max() : 0;
     }
 
   protected:

--- a/src/core/input/state.hpp
+++ b/src/core/input/state.hpp
@@ -7,10 +7,10 @@ namespace hydra::input {
 struct NpadState {
     horizon::services::hid::NpadButtons buttons{
         horizon::services::hid::NpadButtons::None};
-    f32 analog_l_x{0.0f};
-    f32 analog_l_y{0.0f};
-    f32 analog_r_x{0.0f};
-    f32 analog_r_y{0.0f};
+    i32 analog_l_x;
+    i32 analog_l_y;
+    i32 analog_r_x;
+    i32 analog_r_y;
 };
 
 struct TouchState {


### PR DESCRIPTION
this pr makes the values returned from `GetAxisValue` integer from the start, instead of converting them in `npad.cpp`
this is avoids a double conversion in the SDL input port (`SDL_GetGamepadAxis` returns `i16` for axis values).

**needs testing.**