### PR TITLE
Add null renderer

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -6,7 +6,7 @@ TOML11_DEFINE_CONVERSION_ENUM(hydra::InputBackend, AppleGameController,
                               "Apple GameController", Sdl, "SDL")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::CpuBackend, AppleHypervisor,
                               "Apple Hypervisor", Dynarmic, "dynarmic")
-TOML11_DEFINE_CONVERSION_ENUM(hydra::GpuRenderer, Metal, "Metal")
+TOML11_DEFINE_CONVERSION_ENUM(hydra::GpuRenderer, Null, "null", Metal, "Metal")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::ShaderBackend, Msl, "MSL", Air, "AIR")
 TOML11_DEFINE_CONVERSION_ENUM(hydra::Resolution, Auto, "auto", _720p, "720p",
                               _1080p, "1080p", _1440p, "1440p", _2160p, "2160p",

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -21,6 +21,7 @@ enum class CpuBackend : u32 {
 };
 
 enum class GpuRenderer : u32 {
+    Null,
     Metal,
 };
 
@@ -119,7 +120,13 @@ class Config {
         return CpuBackend::Dynarmic;
 #endif
     }
-    static GpuRenderer GetDefaultGpuRenderer() { return GpuRenderer::Metal; }
+    static GpuRenderer GetDefaultGpuRenderer() {
+#ifdef PLATFORM_APPLE
+        return GpuRenderer::Metal;
+#else
+        return GpuRenderer::Null;
+#endif
+    }
     static ShaderBackend GetDefaultShaderBackend() {
         return ShaderBackend::Msl;
     }
@@ -226,7 +233,7 @@ ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, InputBackend, AppleGameController,
                                    "Apple GameController", Sdl, "SDL")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, CpuBackend, AppleHypervisor,
                                    "Apple Hypervisor", Dynarmic, "dynarmic")
-ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, GpuRenderer, Metal, "Metal")
+ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, GpuRenderer, Null, "Null", Metal, "Metal")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, ShaderBackend, Msl, "MSL", Air, "AIR")
 ENABLE_ENUM_FORMATTING_AND_CASTING(hydra, Resolution, Auto, "auto", _720p,
                                    "720p", _1080p, "1080p", _1440p, "1440p",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -579,6 +579,14 @@ add_library(hydra-core
     hw/tegra_x1/gpu/renderer/index_cache.cpp
     hw/tegra_x1/gpu/renderer/index_cache.hpp
     hw/tegra_x1/gpu/renderer/renderer.hpp
+    hw/tegra_x1/gpu/renderer/null/surface_compositor.cpp
+    hw/tegra_x1/gpu/renderer/null/surface_compositor.hpp
+    hw/tegra_x1/gpu/renderer/null/buffer.cpp
+    hw/tegra_x1/gpu/renderer/null/buffer.hpp
+    hw/tegra_x1/gpu/renderer/null/texture.cpp
+    hw/tegra_x1/gpu/renderer/null/texture.hpp
+    hw/tegra_x1/gpu/renderer/null/renderer.cpp
+    hw/tegra_x1/gpu/renderer/null/renderer.hpp
     hw/tegra_x1/gpu/renderer/metal/const.hpp
     hw/tegra_x1/gpu/renderer/metal/maxwell_to_mtl.cpp
     hw/tegra_x1/gpu/renderer/metal/maxwell_to_mtl.hpp

--- a/src/core/hw/tegra_x1/gpu/gpu.cpp
+++ b/src/core/hw/tegra_x1/gpu/gpu.cpp
@@ -2,7 +2,11 @@
 
 #include "core/hw/tegra_x1/cpu/mmu.hpp"
 #include "core/hw/tegra_x1/gpu/const.hpp"
+
+#ifdef PLATFORM_APPLE
 #include "core/hw/tegra_x1/gpu/renderer/metal/renderer.hpp"
+#endif
+#include "core/hw/tegra_x1/gpu/renderer/null/renderer.hpp"
 
 namespace hydra::hw::tegra_x1::gpu {
 
@@ -12,7 +16,13 @@ renderer::IRenderer* CreateRenderer() {
     const auto renderer_type = CONFIG_INSTANCE.GetGpuRenderer();
     switch (renderer_type) {
     case GpuRenderer::Metal:
+#ifdef PLATFORM_APPLE
         return new renderer::metal::Renderer();
+#else
+        LOG_FATAL(Gpu, "Metal renderer not supported");
+#endif
+    case GpuRenderer::Null:
+        return new renderer::null::Renderer();
     default:
         LOG_FATAL(Gpu, "Unknown Gpu renderer {}", renderer_type);
     }

--- a/src/core/hw/tegra_x1/gpu/renderer/null/buffer.cpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/buffer.cpp
@@ -1,0 +1,27 @@
+#include "core/hw/tegra_x1/gpu/renderer/null/buffer.hpp"
+
+#include "core/hw/tegra_x1/gpu/renderer/null/renderer.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+Buffer::Buffer(u64 size) : BufferBase(size) { buffer = new u8[size]; }
+Buffer::~Buffer() { delete[] buffer; }
+
+void Buffer::CopyFrom([[maybe_unused]] ICommandBuffer* command_buffer,
+                      [[maybe_unused]] ITextureView* src,
+                      [[maybe_unused]] const uint3 src_origin,
+                      [[maybe_unused]] const uint3 src_size,
+                      [[maybe_unused]] const Range<u32> src_levels,
+                      [[maybe_unused]] const Range<u32> src_layers,
+                      [[maybe_unused]] u64 dst_offset) {}
+
+void Buffer::CopyFromImpl([[maybe_unused]] const uptr data,
+                          [[maybe_unused]] u64 dst_offset,
+                          [[maybe_unused]] u64 size_) {}
+void Buffer::CopyFromImpl([[maybe_unused]] ICommandBuffer* command_buffer,
+                          [[maybe_unused]] BufferBase* src,
+                          [[maybe_unused]] u64 dst_offset,
+                          [[maybe_unused]] u64 src_offset,
+                          [[maybe_unused]] u64 size_) {}
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/buffer.hpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/buffer.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "core/hw/tegra_x1/gpu/renderer/buffer_base.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+class Buffer final : public BufferBase {
+  public:
+    Buffer(u64 size);
+    ~Buffer() override;
+
+    uptr GetPtr() const override { return reinterpret_cast<uptr>(buffer); }
+
+    // Copying
+    void CopyFrom(ICommandBuffer* command_buffer, ITextureView* src,
+                  const uint3 src_origin, const uint3 src_size,
+                  const Range<u32> src_levels, const Range<u32> src_layers,
+                  u64 dst_offset) override;
+
+  private:
+    u8* buffer;
+
+    void CopyFromImpl(const uptr data, u64 dst_offset, u64 size_) override;
+    void CopyFromImpl(ICommandBuffer* command_buffer, BufferBase* src,
+                      u64 dst_offset, u64 src_offset, u64 size_) override;
+
+  public:
+    GETTER(buffer, GetBuffer);
+};
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/renderer.cpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/renderer.cpp
@@ -1,0 +1,143 @@
+#include "core/hw/tegra_x1/gpu/renderer/null/renderer.hpp"
+
+#include "core/hw/tegra_x1/gpu/renderer/null/buffer.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/null/surface_compositor.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/null/texture.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+CommandBuffer::CommandBuffer() {}
+CommandBuffer::~CommandBuffer() {}
+
+Sampler::Sampler(const SamplerDescriptor& descriptor)
+    : SamplerBase(descriptor) {}
+Sampler::~Sampler() {}
+
+RenderPass::RenderPass(const RenderPassDescriptor& descriptor)
+    : RenderPassBase(descriptor) {}
+RenderPass::~RenderPass() {}
+
+Pipeline::Pipeline(const PipelineDescriptor& descriptor)
+    : PipelineBase(descriptor) {}
+Pipeline::~Pipeline() {}
+
+Shader::Shader(const ShaderDescriptor& descriptor) : ShaderBase(descriptor) {}
+Shader::~Shader() {}
+
+Renderer::Renderer() {}
+Renderer::~Renderer() {}
+
+void Renderer::SetSurface([[maybe_unused]] void* surface) {}
+
+ISurfaceCompositor* Renderer::AcquireNextSurface() {
+    return new SurfaceCompositor();
+}
+
+BufferBase* Renderer::CreateBuffer(u64 size) { return new Buffer(size); }
+
+BufferBase* Renderer::AllocateTemporaryBuffer(const u64 size) {
+    return new Buffer(size);
+}
+
+void Renderer::FreeTemporaryBuffer(BufferBase* buffer) {
+    auto buffer_impl = static_cast<Buffer*>(buffer);
+    delete buffer_impl;
+}
+
+ITexture* Renderer::CreateTexture(const TextureDescriptor& descriptor) {
+    return new Texture(descriptor);
+}
+
+void Renderer::BlitTexture(
+    [[maybe_unused]] ICommandBuffer* command_buffer,
+    [[maybe_unused]] ITextureView* src, [[maybe_unused]] float3 src_origin,
+    [[maybe_unused]] uint3 src_size, [[maybe_unused]] u32 src_level,
+    [[maybe_unused]] u32 src_layer, [[maybe_unused]] ITextureView* dst,
+    [[maybe_unused]] float3 dst_origin, [[maybe_unused]] uint3 dst_size,
+    [[maybe_unused]] u32 dst_level, [[maybe_unused]] u32 dst_layer,
+    [[maybe_unused]] u32 level_count, [[maybe_unused]] u32 layer_count) {}
+
+SamplerBase* Renderer::CreateSampler(const SamplerDescriptor& descriptor) {
+    return new Sampler(descriptor);
+}
+
+ICommandBuffer* Renderer::CreateCommandBuffer() { return new CommandBuffer(); }
+
+RenderPassBase*
+Renderer::CreateRenderPass(const RenderPassDescriptor& descriptor) {
+    return new RenderPass(descriptor);
+}
+
+void Renderer::BindRenderPass(
+    [[maybe_unused]] const RenderPassBase* render_pass) {}
+
+void Renderer::ClearColor([[maybe_unused]] ICommandBuffer* command_buffer,
+                          [[maybe_unused]] u32 render_target_id,
+                          [[maybe_unused]] u32 layer, [[maybe_unused]] u8 mask,
+                          [[maybe_unused]] const uint4 color) {}
+
+void Renderer::ClearDepth([[maybe_unused]] ICommandBuffer* command_buffer,
+                          [[maybe_unused]] u32 layer,
+                          [[maybe_unused]] const float value) {}
+
+void Renderer::ClearStencil([[maybe_unused]] ICommandBuffer* command_buffer,
+                            [[maybe_unused]] u32 layer,
+                            [[maybe_unused]] const u32 value) {}
+
+ShaderBase* Renderer::CreateShader(const ShaderDescriptor& descriptor) {
+    return new Shader(descriptor);
+}
+
+PipelineBase* Renderer::CreatePipeline(const PipelineDescriptor& descriptor) {
+    return new Pipeline(descriptor);
+}
+
+void Renderer::BindPipeline([[maybe_unused]] const PipelineBase* pipeline) {}
+
+void Renderer::SetDepthTestEnabled([[maybe_unused]] bool enabled) {}
+void Renderer::SetDepthWriteEnabled([[maybe_unused]] bool enabled) {}
+void Renderer::SetDepthCompareOp([[maybe_unused]] engines::CompareOp op) {}
+
+// Viewport and scissor
+void Renderer::SetViewport([[maybe_unused]] u32 index,
+                           [[maybe_unused]] const Viewport& viewport) {}
+void Renderer::SetScissor([[maybe_unused]] u32 index,
+                          [[maybe_unused]] const Scissor& scissor) {}
+
+// Resource binding
+void Renderer::BindVertexBuffer([[maybe_unused]] const BufferView& buffer,
+                                [[maybe_unused]] u32 index) {}
+void Renderer::BindIndexBuffer([[maybe_unused]] const BufferView& index_buffer,
+                               [[maybe_unused]] engines::IndexType index_type) {
+}
+void Renderer::BindUniformBuffer([[maybe_unused]] const BufferView& buffer,
+                                 [[maybe_unused]] ShaderType shader_type,
+                                 [[maybe_unused]] u32 index) {}
+void Renderer::BindTexture([[maybe_unused]] ITextureView* texture,
+                           [[maybe_unused]] SamplerBase* sampler,
+                           [[maybe_unused]] ShaderType shader_type,
+                           [[maybe_unused]] u32 index) {}
+
+// Resource unbinding
+void Renderer::UnbindUniformBuffers([[maybe_unused]] ShaderType shader_type) {}
+void Renderer::UnbindTextures([[maybe_unused]] ShaderType shader_type) {}
+
+// Draw
+void Renderer::Draw(
+    [[maybe_unused]] ICommandBuffer* command_buffer,
+    [[maybe_unused]] const engines::PrimitiveType primitive_type,
+    [[maybe_unused]] const u32 start, [[maybe_unused]] const u32 count,
+    [[maybe_unused]] const u32 base_instance,
+    [[maybe_unused]] const u32 instance_count) {}
+void Renderer::DrawIndexed(
+    [[maybe_unused]] ICommandBuffer* command_buffer,
+    [[maybe_unused]] const engines::PrimitiveType primitive_type,
+    [[maybe_unused]] const u32 start, [[maybe_unused]] const u32 count,
+    [[maybe_unused]] const u32 base_vertex,
+    [[maybe_unused]] const u32 base_instance,
+    [[maybe_unused]] const u32 instance_count) {}
+
+void Renderer::BeginCapture() {}
+void Renderer::EndCapture() {}
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/renderer.hpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/renderer.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "core/hw/tegra_x1/gpu/renderer/command_buffer.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/pipeline_base.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/render_pass_base.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/renderer.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/sampler_base.hpp"
+#include "core/hw/tegra_x1/gpu/renderer/shader_base.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+class Buffer;
+class TextureView;
+
+class CommandBuffer final : public ICommandBuffer {
+  public:
+    CommandBuffer();
+    ~CommandBuffer() override;
+};
+
+class Sampler final : public SamplerBase {
+  public:
+    Sampler(const SamplerDescriptor& descriptor);
+    ~Sampler() override;
+};
+
+class RenderPass final : public RenderPassBase {
+  public:
+    RenderPass(const RenderPassDescriptor& descriptor);
+    ~RenderPass() override;
+};
+
+class Pipeline final : public PipelineBase {
+  public:
+    Pipeline(const PipelineDescriptor& descriptor);
+    ~Pipeline() override;
+};
+
+class Shader final : public ShaderBase {
+  public:
+    Shader(const ShaderDescriptor& descriptor);
+    ~Shader() override;
+};
+
+class Renderer : public IRenderer {
+  public:
+    Renderer();
+    ~Renderer() override;
+
+    // Surface
+    void SetSurface(void* surface) override;
+    ISurfaceCompositor* AcquireNextSurface() override;
+
+    // Buffer
+    BufferBase* CreateBuffer(u64 size) override;
+    BufferBase* AllocateTemporaryBuffer(const u64 size) override;
+    void FreeTemporaryBuffer(BufferBase* buffer) override;
+
+    // Texture
+    ITexture* CreateTexture(const TextureDescriptor& descriptor) override;
+    void BlitTexture(ICommandBuffer* command_buffer, ITextureView* src,
+                     float3 src_origin, uint3 src_size, u32 src_level,
+                     u32 src_layer, ITextureView* dst, float3 dst_origin,
+                     uint3 dst_size, u32 dst_level, u32 dst_layer,
+                     u32 level_count, u32 layer_count) override;
+
+    // Sampler
+    SamplerBase* CreateSampler(const SamplerDescriptor& descriptor) override;
+
+    // Command buffer
+    ICommandBuffer* CreateCommandBuffer() override;
+
+    // Render pass
+    RenderPassBase*
+    CreateRenderPass(const RenderPassDescriptor& descriptor) override;
+    void BindRenderPass(const RenderPassBase* render_pass) override;
+
+    // Clear
+    void ClearColor(ICommandBuffer* command_buffer, u32 render_target_id,
+                    u32 layer, u8 mask, const uint4 color) override;
+    void ClearDepth(ICommandBuffer* command_buffer, u32 layer,
+                    const float value) override;
+    void ClearStencil(ICommandBuffer* command_buffer, u32 layer,
+                      const u32 value) override;
+
+    // Shader
+    ShaderBase* CreateShader(const ShaderDescriptor& descriptor) override;
+
+    // Pipeline
+    PipelineBase* CreatePipeline(const PipelineDescriptor& descriptor) override;
+    void BindPipeline(const PipelineBase* pipeline) override;
+
+    // Depth stencil
+    void SetDepthTestEnabled(bool enabled) override;
+    void SetDepthWriteEnabled(bool enabled) override;
+    void SetDepthCompareOp(engines::CompareOp op) override;
+
+    // Viewport and scissor
+    void SetViewport(u32 index, const Viewport& viewport) override;
+    void SetScissor(u32 index, const Scissor& scissor) override;
+
+    // Resource binding
+    void BindVertexBuffer(const BufferView& buffer, u32 index) override;
+    void BindIndexBuffer(const BufferView& index_buffer,
+                         engines::IndexType index_type) override;
+    void BindUniformBuffer(const BufferView& buffer, ShaderType shader_type,
+                           u32 index) override;
+    void BindTexture(ITextureView* texture, SamplerBase* sampler,
+                     ShaderType shader_type, u32 index) override;
+
+    // Resource unbinding
+    void UnbindUniformBuffers(ShaderType shader_type) override;
+    void UnbindTextures(ShaderType shader_type) override;
+
+    // Draw
+    void Draw(ICommandBuffer* command_buffer,
+              const engines::PrimitiveType primitive_type, const u32 start,
+              const u32 count, const u32 base_instance,
+              const u32 instance_count) override;
+    void DrawIndexed(ICommandBuffer* command_buffer,
+                     const engines::PrimitiveType primitive_type,
+                     const u32 start, const u32 count, const u32 base_vertex,
+                     const u32 base_instance,
+                     const u32 instance_count) override;
+
+  protected:
+    // Capture
+    void BeginCapture() override;
+    void EndCapture() override;
+};
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/surface_compositor.cpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/surface_compositor.cpp
@@ -1,0 +1,18 @@
+#include "core/hw/tegra_x1/gpu/renderer/null/surface_compositor.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+SurfaceCompositor::SurfaceCompositor() {}
+SurfaceCompositor::~SurfaceCompositor() {}
+
+void SurfaceCompositor::DrawTexture(
+    [[maybe_unused]] ICommandBuffer* command_buffer,
+    [[maybe_unused]] const ITextureView* texture,
+    [[maybe_unused]] const FloatRect2D src_rect,
+    [[maybe_unused]] const FloatRect2D dst_rect,
+    [[maybe_unused]] bool transparent, [[maybe_unused]] f32 opacity) {}
+
+void SurfaceCompositor::Present(
+    [[maybe_unused]] ICommandBuffer* command_buffer) {}
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/surface_compositor.hpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/surface_compositor.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "core/hw/tegra_x1/gpu/renderer/surface_compositor.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+class Renderer;
+
+class SurfaceCompositor final : public ISurfaceCompositor {
+  public:
+    SurfaceCompositor();
+    ~SurfaceCompositor() override;
+
+    void DrawTexture(ICommandBuffer* command_buffer,
+                     const ITextureView* texture, const FloatRect2D src_rect,
+                     const FloatRect2D dst_rect, bool transparent,
+                     f32 opacity) override;
+    void Present(ICommandBuffer* command_buffer) override;
+};
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/texture.cpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/texture.cpp
@@ -1,0 +1,36 @@
+#include "core/hw/tegra_x1/gpu/renderer/null/texture.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+Texture::Texture(const TextureDescriptor& descriptor) : ITexture(descriptor) {}
+Texture::~Texture() {}
+
+ITextureView* Texture::CreateView(
+    [[maybe_unused]] const TextureViewDescriptor& view_descriptor) {
+    return nullptr;
+}
+
+void Texture::CopyFrom([[maybe_unused]] ICommandBuffer* command_buffer,
+                       [[maybe_unused]] const BufferBase* src,
+                       [[maybe_unused]] const Range<u32> dst_levels,
+                       [[maybe_unused]] const Range<u32> dst_layers) {}
+void Texture::CopyFrom([[maybe_unused]] ICommandBuffer* command_buffer,
+                       [[maybe_unused]] const ITexture* src,
+                       [[maybe_unused]] const u32 src_level,
+                       [[maybe_unused]] const u32 src_layer,
+                       [[maybe_unused]] const u32 dst_level,
+                       [[maybe_unused]] const u32 dst_layer,
+                       [[maybe_unused]] const u32 level_count,
+                       [[maybe_unused]] const u32 layer_count) {}
+void Texture::CopyFrom([[maybe_unused]] ICommandBuffer* command_buffer,
+                       [[maybe_unused]] const ITexture* src,
+                       [[maybe_unused]] const uint3 src_origin,
+                       [[maybe_unused]] const u32 src_level,
+                       [[maybe_unused]] const u32 src_layer,
+                       [[maybe_unused]] const uint3 dst_origin,
+                       [[maybe_unused]] const u32 dst_level,
+                       [[maybe_unused]] const u32 dst_layer,
+                       [[maybe_unused]] const uint3 size,
+                       [[maybe_unused]] const u32 layer_count) {}
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null

--- a/src/core/hw/tegra_x1/gpu/renderer/null/texture.hpp
+++ b/src/core/hw/tegra_x1/gpu/renderer/null/texture.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "core/hw/tegra_x1/gpu/renderer/texture.hpp"
+
+namespace hydra::hw::tegra_x1::gpu::renderer::null {
+
+class Texture final : public ITexture {
+  public:
+    Texture(const TextureDescriptor& descriptor);
+    ~Texture() override;
+
+    ITextureView*
+    CreateView(const TextureViewDescriptor& view_descriptor) override;
+
+    // Copying
+    void CopyFrom(ICommandBuffer* command_buffer, const BufferBase* src,
+                  const Range<u32> dst_levels,
+                  const Range<u32> dst_layers) override;
+    void CopyFrom(ICommandBuffer* command_buffer, const ITexture* src,
+                  const u32 src_level, const u32 src_layer, const u32 dst_level,
+                  const u32 dst_layer, const u32 level_count,
+                  const u32 layer_count) override;
+    void CopyFrom(ICommandBuffer* command_buffer, const ITexture* src,
+                  const uint3 src_origin, const u32 src_level,
+                  const u32 src_layer, const uint3 dst_origin,
+                  const u32 dst_level, const u32 dst_layer, const uint3 size,
+                  const u32 layer_count) override;
+};
+
+} // namespace hydra::hw::tegra_x1::gpu::renderer::null


### PR DESCRIPTION
adds null renderer

notes:
- files are split in `gpu/renderer/null` by if the class has any methods. the ones without are clumped into `renderer`
- was tested with nullequal/portable branch